### PR TITLE
fix: harden TUI rendering, search hot paths, and error reporting

### DIFF
--- a/src/fast_resume/cli.py
+++ b/src/fast_resume/cli.py
@@ -6,6 +6,7 @@ import click
 import humanize
 from rich.console import Console
 from rich.table import Table
+from rich.text import Text
 
 from .config import AGENTS, INDEX_DIR
 from .index import TantivyIndex
@@ -195,8 +196,11 @@ def _show_stats() -> None:
             if data_dir.startswith(home):
                 data_dir = "~" + data_dir[len(home) :]
 
+            # `data_dir` can be user-controlled (e.g. Crush reads it from
+            # `~/.local/share/crush/projects.json`); wrap in Text to avoid
+            # markup parsing. `agent_name` is hardcoded but kept consistent.
             agent_table.add_row(
-                f"[{color}]{agent_name}[/{color}]",
+                Text(agent_name, style=color),
                 str(raw_stats.file_count),
                 humanize.naturalsize(raw_stats.total_bytes),
                 str(sessions) if sessions > 0 else "[dim]0[/dim]",
@@ -204,11 +208,11 @@ def _show_stats() -> None:
                 humanize.naturalsize(content_size)
                 if content_size > 0
                 else "[dim]-[/dim]",
-                f"[dim]{data_dir}[/dim]",
+                Text(data_dir, style="dim"),
             )
         else:
             agent_table.add_row(
-                f"[{color}]{agent_name}[/{color}]",
+                Text(agent_name, style=color),
                 "[dim]-[/dim]",
                 "[dim]-[/dim]",
                 "[dim]-[/dim]",
@@ -273,7 +277,9 @@ def _show_stats() -> None:
             display_dir = directory
             if display_dir.startswith(home):
                 display_dir = "~" + display_dir[len(home) :]
-            dir_table.add_row(display_dir, str(sessions), f"{messages:,}")
+            # `display_dir` comes from session metadata on disk — wrap in
+            # Text so Rich doesn't interpret embedded markup.
+            dir_table.add_row(Text(display_dir), str(sessions), f"{messages:,}")
 
         console.print(dir_table)
 
@@ -310,11 +316,13 @@ def _list_sessions(query: str, agent: str | None, directory: str | None) -> None
         if len(directory_display) > 35:
             directory_display = "..." + directory_display[-32:]
 
+        # Wrap untrusted strings in Text() so Rich doesn't interpret embedded
+        # markup. Session title/directory/id originate from JSON on disk.
         table.add_row(
-            f"[{agent_style}]{session.agent}[/{agent_style}]",
-            title,
-            directory_display,
-            session.id,
+            Text(session.agent, style=agent_style),
+            Text(title),
+            Text(directory_display),
+            Text(session.id),
         )
 
     console.print(table)

--- a/src/fast_resume/index.py
+++ b/src/fast_resume/index.py
@@ -737,11 +737,20 @@ class TantivyIndex:
         exact_query = index.parse_query(query, ["title", "content"])
         boosted_exact = tantivy.Query.boost_query(exact_query, 5.0)
 
+        # Cap the fuzzy expansion. Each kept term creates two prefix-fuzzy
+        # queries which each can expand to many posting-list scans; without
+        # a cap an adversarial query like a long line of one-character tokens
+        # can blow up search latency on a large index.
+        max_fuzzy_terms = 8
+        min_term_len = 2
+
         # Fuzzy match queries for typo tolerance
         fuzzy_parts: list[tuple[tantivy.Occur, tantivy.Query]] = []
         for term in query.split():
-            if not term:
+            if len(term) < min_term_len:
                 continue
+            if len(fuzzy_parts) >= max_fuzzy_terms:
+                break
             # Fuzzy query for title and content
             fuzzy_title = tantivy.Query.fuzzy_term_query(
                 schema, "title", term, distance=1, prefix=True

--- a/src/fast_resume/search.py
+++ b/src/fast_resume/search.py
@@ -155,20 +155,34 @@ class SessionSearch:
 
         # Thread-safe batch buffer for progressive indexing
         lock = threading.Lock()
+        # The Tantivy writer is exclusive; serialize commits with their own
+        # lock so adapter callbacks aren't blocked from appending to the
+        # buffer while a flush is in progress.
+        writer_lock = threading.Lock()
         pending_sessions: list[Session] = []
         all_deleted_ids: list[str] = []
         sessions_since_progress = 0
 
         def flush_pending() -> None:
-            """Flush pending sessions to index (must be called with lock held)."""
+            """Flush buffered sessions to Tantivy.
+
+            Snapshot the buffer under `lock` (so callbacks can keep
+            appending), then commit under `writer_lock` (Tantivy's writer
+            is exclusive — concurrent flushes raise LockBusy).
+            """
             nonlocal pending_sessions
-            if pending_sessions:
-                self._index.update_sessions(pending_sessions)
+            with lock:
+                if not pending_sessions:
+                    return
+                batch = pending_sessions
                 pending_sessions = []
+            with writer_lock:
+                self._index.update_sessions(batch)
 
         def handle_session(session: Session) -> None:
             """Buffer session for batched indexing (thread-safe)."""
             nonlocal total_new, total_updated, sessions_since_progress
+            should_flush = False
             with lock:
                 # Add to lookup immediately for search during streaming
                 self._sessions_by_id[session.id] = session
@@ -182,8 +196,10 @@ class SessionSearch:
                 sessions_since_progress += 1
                 if sessions_since_progress >= batch_size:
                     sessions_since_progress = 0
-                    flush_pending()  # Commit before UI update so search sees new sessions
-                    on_progress()
+                    should_flush = True
+            if should_flush:
+                flush_pending()  # Commit before UI update so search sees new sessions
+                on_progress()
 
         def get_incremental(adapter):
             return adapter.find_sessions_incremental(
@@ -198,20 +214,18 @@ class SessionSearch:
                 for future in as_completed(futures):
                     _new_or_modified, deleted_ids = future.result()
 
-                    with lock:
-                        # Flush pending sessions when adapter completes
-                        flush_pending()
+                    # Flush outside the deletion-accumulation critical section.
+                    flush_pending()
 
-                        # Accumulate deletions (will be processed at the end)
-                        if deleted_ids:
+                    if deleted_ids:
+                        with lock:
                             all_deleted_ids.extend(deleted_ids)
                             for sid in deleted_ids:
                                 self._sessions_by_id.pop(sid, None)
                             total_deleted += len(deleted_ids)
         finally:
             # Final flush of any remaining sessions
-            with lock:
-                flush_pending()
+            flush_pending()
             # Process all deletions in a single operation
             if all_deleted_ids:
                 self._index.delete_sessions(all_deleted_ids)
@@ -292,12 +306,15 @@ class SessionSearch:
         return self._index.get_session_count(agent_filter)
 
     def get_agents_with_sessions(self) -> set[str]:
-        """Get the set of agent names that have at least one session."""
-        agents = set()
-        for adapter in self.adapters:
-            if self._index.get_session_count(adapter.name) > 0:
-                agents.add(adapter.name)
-        return agents
+        """Get the set of agent names that have at least one session.
+
+        Uses a single index pass (via the cached `get_known_sessions`
+        traversal) instead of N per-agent count queries — each of those
+        would reopen the Tantivy searcher and round-trip the index.
+        """
+        adapter_names = {adapter.name for adapter in self.adapters}
+        known = self._index.get_known_sessions()
+        return {agent for (_mtime, agent) in known.values() if agent in adapter_names}
 
     def get_adapter_for_session(self, session: Session):
         """Get the adapter for a session."""

--- a/src/fast_resume/tui/app.py
+++ b/src/fast_resume/tui/app.py
@@ -6,6 +6,7 @@ import shlex
 import time
 from collections.abc import Callable
 
+from rich.markup import escape as escape_markup
 from textual import on, work
 from textual.app import App, ComposeResult
 from textual.css.query import NoMatches
@@ -303,26 +304,42 @@ class FastResumeApp(App):
     def _check_for_updates(self) -> None:
         """Check PyPI for newer version and notify if available."""
         import json
+        import urllib.error
         import urllib.request
 
         from .. import __version__
 
+        # Cap the response body so a misbehaving / compromised network path
+        # can't stream an unbounded payload into memory.
+        max_response_bytes = 512 * 1024
         try:
             url = "https://pypi.org/pypi/fast-resume/json"
-            with urllib.request.urlopen(url, timeout=3) as response:
-                data = json.load(response)
-                latest = data["info"]["version"]
+            # `url` is a constant literal above; not user-controlled.
+            with urllib.request.urlopen(url, timeout=3) as response:  # nosemgrep
+                raw = response.read(max_response_bytes + 1)
+            if len(raw) > max_response_bytes:
+                logger.debug("PyPI update check: response exceeded cap; skipping")
+                return
+            data = json.loads(raw)
+            latest = data["info"]["version"]
 
             if latest != __version__:
                 self._available_update = latest
+                # `latest` is from the PyPI response — treat as untrusted
+                # for Rich markup purposes.
+                safe_latest = escape_markup(str(latest))
                 self.call_from_thread(
                     self.notify,
-                    f"{__version__} → {latest}\nRun [bold]uv tool upgrade fast-resume[/bold] to update",
+                    f"{__version__} → {safe_latest}\nRun [bold]uv tool upgrade fast-resume[/bold] to update",
                     title="Update available",
                     timeout=5,
                 )
-        except Exception:
-            pass  # Silently ignore update check failures
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as e:
+            # Network or response-shape problems are expected; degrade silently.
+            logger.debug("Update check skipped: %s", e)
+        except (KeyError, TypeError) as e:
+            # The PyPI schema could change in a future API revision.
+            logger.debug("Update check: unexpected response shape: %s", e)
 
     # -------------------------------------------------------------------------
     # Search logic
@@ -467,10 +484,13 @@ class FastResumeApp(App):
         cmd_str = shlex.join(resume_cmd)
         full_cmd = f"cd {shlex.quote(directory)} && {cmd_str}"
 
+        # `full_cmd` contains session.directory (untrusted, from disk JSON).
+        # Escape before passing to notify (markup=True by default).
+        safe_full_cmd = escape_markup(full_cmd)
         if copy_to_clipboard(full_cmd):
-            self.notify(f"Copied: {full_cmd}", timeout=3)
+            self.notify(f"Copied: {safe_full_cmd}", timeout=3)
         else:
-            self.notify(full_cmd, title="Clipboard unavailable", timeout=5)
+            self.notify(safe_full_cmd, title="Clipboard unavailable", timeout=5)
 
     def _on_copy_yolo_modal_result(self, result: bool | None) -> None:
         """Handle result from yolo mode modal for copy action."""
@@ -482,10 +502,13 @@ class FastResumeApp(App):
         if not self.selected_session:
             return
 
-        # Crush doesn't support CLI resume - show a toast instead
+        # Crush doesn't support CLI resume - show a toast instead.
+        # Escape the directory; it originates from on-disk JSON metadata and
+        # could otherwise be interpreted as Rich markup by the notification.
         if self.selected_session.agent == "crush":
+            safe_dir = escape_markup(self.selected_session.directory)
             self.notify(
-                f"Crush doesn't support CLI resume. Open crush in: [bold]{self.selected_session.directory}[/bold] and use ctrl+s to find your session",
+                f"Crush doesn't support CLI resume. Open crush in: [bold]{safe_dir}[/bold] and use ctrl+s to find your session",
                 title="Cannot resume",
                 severity="warning",
                 timeout=5,
@@ -629,5 +652,6 @@ class FastResumeApp(App):
         """Get currently displayed sessions (for backward compatibility)."""
         try:
             return self.query_one(ResultsTable).displayed_sessions
-        except Exception:
+        except NoMatches:
+            # Widget tree not mounted yet (or torn down): legitimate empty.
             return []


### PR DESCRIPTION
Rich parses `[bold red]…[/bold red]` in any string passed to `print`, `Table.add_row`, or `notify`. Session titles, directories, and ids all come from on-disk JSON that external CLIs write, so a crafted session id like `[blink]pwned[/blink]` would render styled text in the TUI. Fixed six call sites: stats tables now pass `Text(...)` objects, the copy-command toast escapes `full_cmd` before display (the clipboard still gets the raw string), and the Crush "cannot resume" toast escapes the directory.

Two performance changes: `get_agents_with_sessions` was opening the Tantivy searcher once per adapter (7x) to count sessions; it now does a single pass through `get_known_sessions`. And `flush_pending` inside `index_sessions_parallel` was holding the buffer lock through `writer.commit()`, serialising every adapter thread through disk I/O. A `LockBusy` crash under heavy concurrent indexing prompted the fix. The buffer is now snapshotted under the lock, released, then committed under a separate `writer_lock`. Response body from the PyPI version check is now capped at 512 KB.

Small cleanup: `_check_for_updates` had a bare `except Exception: pass` that silently swallowed PyPI schema changes; narrowed to specific network and parse errors with `logger.debug`. `_displayed_sessions` had the same catch.

## Test plan

- [x] `uv run pytest` (364 tests pass)
- [x] `uv run ruff check . && uv run ruff format --check . && uv run ty check src/`
- [x] Codacy static analysis: 0 new issues

---

> **AI Disclosure:** Developed with [Claude Code](https://claude.ai/code) assistance. Reviewed and verified by the contributor; all tests pass.