### PR TITLE
feat(tui): redesign launch modal; add PATH validation; fix preview-pane artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Resume sessions with auto-approve / skip-permissions flags:
 
 **Auto-detection:** Codex and Vibe store the permissions mode in their session files. Sessions originally started in yolo mode are automatically resumed in yolo mode.
 
-**Interactive prompt:** For agents that support yolo but don't store it (Claude, Copilot CLI), you'll see a modal asking whether to resume in yolo mode. Use Tab to toggle, Enter to confirm.
+**Interactive prompt:** For agents that support yolo but don't store it (Claude, Copilot CLI), you'll see a Launch modal with a yolo checkbox. Press `Space`/`y`/`n` to toggle, then Enter to launch (or Esc to cancel).
 
 **Force yolo:** Use `fr --yolo` to skip the prompt and always resume in yolo mode, if supported.
 
@@ -187,15 +187,16 @@ Options:
 | `Ctrl+P`  | Open command palette                  |
 | `q`/`Esc` | Quit                                  |
 
-### Yolo Mode Modal
+### Launch Modal
 
-| Key             | Action            |
-| --------------- | ----------------- |
-| `Tab` / `←` `→` | Toggle selection  |
-| `Enter`         | Confirm selection |
-| `y`             | Select Yolo       |
-| `n`             | Select No         |
-| `Esc`           | Cancel            |
+| Key             | Action                                  |
+| --------------- | --------------------------------------- |
+| `Tab` / `←` `→` | Move focus between Cancel and Launch    |
+| `Space`         | Toggle yolo checkbox                    |
+| `y`             | Turn yolo on                            |
+| `n`             | Turn yolo off                           |
+| `Enter`         | Launch (with the checkbox's yolo state) |
+| `Esc`           | Cancel (stay in the TUI)                |
 
 ## Statistics Dashboard
 

--- a/src/fast_resume/cli.py
+++ b/src/fast_resume/cli.py
@@ -1,10 +1,13 @@
 """CLI entry point for fast-resume."""
 
 import os
+import shlex
+import sys
 
 import click
 import humanize
 from rich.console import Console
+from rich.markup import escape as escape_markup
 from rich.table import Table
 
 from .config import AGENTS, INDEX_DIR
@@ -119,8 +122,23 @@ def main(
             # Change to session directory before running command
             if resume_dir:
                 os.chdir(resume_dir)
+            # Print a brief launch banner so the gap between the TUI tearing
+            # down and the agent CLI drawing its own screen isn't silent.
+            # Escape the joined command: session ids come from JSON on disk
+            # and could otherwise be parsed as Rich markup.
+            console = Console()
+            console.print(
+                f"[dim]Launching:[/dim] [bold]{escape_markup(shlex.join(resume_cmd))}[/bold]"
+            )
             # Execute the resume command
-            os.execvp(resume_cmd[0], resume_cmd)
+            try:
+                os.execvp(resume_cmd[0], resume_cmd)
+            except OSError as e:
+                console.print(
+                    f"[bold red]Error:[/bold red] couldn't execute "
+                    f"'{escape_markup(resume_cmd[0])}': {escape_markup(str(e))}"
+                )
+                sys.exit(1)
 
 
 def _show_stats() -> None:

--- a/src/fast_resume/tui/app.py
+++ b/src/fast_resume/tui/app.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import shlex
+import shutil
 import time
 from collections.abc import Callable
 
@@ -92,6 +93,10 @@ class FastResumeApp(App):
         self._search_timer: Timer | None = None
         self._available_update: str | None = None
         self._syncing_filter: bool = False  # Prevent infinite loops during sync
+        # Memo of the last preview we rendered so j/k navigation across the
+        # same session doesn't force a full layout pass on every keypress.
+        self._previewed_session: Session | None = None
+        self._previewed_query: str = ""
 
     def compose(self) -> ComposeResult:
         """Create child widgets."""
@@ -309,7 +314,8 @@ class FastResumeApp(App):
 
         try:
             url = "https://pypi.org/pypi/fast-resume/json"
-            with urllib.request.urlopen(url, timeout=3) as response:
+            # `url` is a constant literal above; not user-controlled.
+            with urllib.request.urlopen(url, timeout=3) as response:  # nosemgrep
                 data = json.load(response)
                 latest = data["info"]["version"]
 
@@ -355,7 +361,44 @@ class FastResumeApp(App):
         except NoMatches:
             return  # Widget not mounted yet
         self.selected_session = table.update_sessions(sessions, self._current_query)
+        # The DataTable's `RowHighlighted` event doesn't fire when the cursor
+        # was already at row 0 before the table was cleared, so the preview
+        # pane would otherwise keep stale content from the previous filter.
+        # Refresh it explicitly here.
+        self._refresh_preview(self.selected_session)
         self._update_session_count()
+
+    def _refresh_preview(self, session: Session | None) -> None:
+        """Sync the preview pane to `session`, resetting scroll and forcing
+        a layout pass so the scrollbar thumb and any inline-image cells from
+        the previous render don't linger.
+
+        Cheap no-op when the preview already shows this session and the
+        search query hasn't changed — protects j/k navigation from doing
+        per-keystroke full repaints.
+        """
+        if (
+            session is not None
+            and session is self._previewed_session
+            and self._current_query == self._previewed_query
+        ):
+            return
+        try:
+            preview = self.query_one(SessionPreview)
+            container = self.query_one("#preview-container")
+        except NoMatches:
+            return
+        preview.update_preview(session, self._current_query)
+        # Reset scroll position so the scrollbar thumb doesn't get stuck as a
+        # stale blue block when switching from a tall preview to a short one.
+        container.scroll_home(animate=False)
+        # Force a layout pass so the VerticalScroll recomputes scrollbar
+        # visibility and so inline-image renderables drawn by the previous
+        # session don't leave artifacts in the terminal cells.
+        container.refresh(layout=True)
+        preview.refresh(layout=True)
+        self._previewed_session = session
+        self._previewed_query = self._current_query
 
     def _update_selected_session(self) -> None:
         """Update the selected session based on cursor position."""
@@ -366,16 +409,14 @@ class FastResumeApp(App):
         session = table.get_selected_session()
         if session:
             self.selected_session = session
-            preview = self.query_one(SessionPreview)
-            preview.update_preview(session, self._current_query)
+            self._refresh_preview(session)
 
     @on(ResultsTable.Selected)
     def on_results_table_selected(self, event: ResultsTable.Selected) -> None:
         """Handle session selection in results table."""
         if event.session:
             self.selected_session = event.session
-            preview = self.query_one(SessionPreview)
-            preview.update_preview(event.session, self._current_query)
+            self._refresh_preview(event.session)
 
     @on(Input.Changed, "#search-input")
     def on_search_changed(self, event: Input.Changed) -> None:
@@ -449,6 +490,11 @@ class FastResumeApp(App):
 
     def action_copy_path(self) -> None:
         """Copy the full resume command (cd + agent resume) to clipboard."""
+        # Textual checks App-level priority bindings even while a modal is
+        # active. Without this guard, pressing `c` during the yolo modal
+        # would stack a second YoloModeModal on top of the first.
+        if isinstance(self.screen, YoloModeModal):
+            return
         if not self.selected_session:
             return
         self._resolve_yolo_mode(self._do_copy_command, self._on_copy_yolo_modal_result)
@@ -497,9 +543,23 @@ class FastResumeApp(App):
     def _do_resume(self, yolo: bool) -> None:
         """Execute the resume with specified yolo mode."""
         assert self.selected_session is not None
-        self._resume_command = self.search_engine.get_resume_command(
+        resume_cmd = self.search_engine.get_resume_command(
             self.selected_session, yolo=yolo
         )
+        # Validate the binary is on PATH before exiting the TUI. Without
+        # this, a missing CLI binary would surface as a raw `FileNotFoundError`
+        # traceback once `os.execvp` runs in `cli.py` — by then the TUI is
+        # already gone and the user has no recourse.
+        if resume_cmd and shutil.which(resume_cmd[0]) is None:
+            agent_name = self.selected_session.agent
+            self.notify(
+                f"Couldn't find '{resume_cmd[0]}' on your PATH. "
+                f"Is the {agent_name} CLI installed?",
+                severity="error",
+                timeout=8,
+            )
+            return
+        self._resume_command = resume_cmd
         self._resume_directory = self.selected_session.directory
         self.exit()
 
@@ -514,10 +574,18 @@ class FastResumeApp(App):
 
     def action_focus_search(self) -> None:
         """Focus the search input."""
+        # Don't yank focus away from the modal's buttons; the modal owns
+        # the screen and `/` should be a no-op while it's up.
+        if isinstance(self.screen, YoloModeModal):
+            return
         self.query_one("#search-input", Input).focus()
 
     def action_toggle_preview(self) -> None:
         """Toggle the preview pane."""
+        # The preview lives on the main screen; toggling it while the modal
+        # is up would change behind-the-modal state invisibly.
+        if isinstance(self.screen, YoloModeModal):
+            return
         self.show_preview = not self.show_preview
         preview_container = self.query_one("#preview-container")
         if self.show_preview:
@@ -585,29 +653,24 @@ class FastResumeApp(App):
 
     def action_accept_suggestion(self) -> None:
         """Accept autocomplete suggestion in search input."""
-        # If a modal is open, let it handle tab for focus switching
+        # When the launch modal is open, Tab uses Textual's default focus
+        # cycling (yolo checkbox → Cancel → Launch), so this binding only
+        # applies to the main search screen.
         if isinstance(self.screen, YoloModeModal):
-            self.screen.action_toggle_focus()
             return
         search_input = self.query_one("#search-input", Input)
         if search_input._suggestion:
             search_input.action_cursor_right()
-
-    def action_cycle_filter(self) -> None:
-        """Cycle to the next agent filter."""
-        try:
-            current_index = FILTER_KEYS.index(self.active_filter)
-            next_index = (current_index + 1) % len(FILTER_KEYS)
-        except ValueError:
-            next_index = 0
-        self._set_filter(FILTER_KEYS[next_index])
 
     async def action_quit(self) -> None:
         """Quit the app, or dismiss modal if one is open."""
         if len(self.screen_stack) > 1:
             top_screen = self.screen_stack[-1]
             if isinstance(top_screen, YoloModeModal):
-                top_screen.dismiss(None)
+                # Route through the modal's own cancel action so any future
+                # cancellation logic (state checks, telemetry, etc.) stays in
+                # one place rather than being silently bypassed here.
+                top_screen.action_cancel()
             return
         self.exit()
 
@@ -623,6 +686,22 @@ class FastResumeApp(App):
     def get_resume_directory(self) -> str | None:
         """Get the directory to change to before running the resume command."""
         return self._resume_directory
+
+    # -------------------------------------------------------------------------
+    # Rendering / repaint hooks
+    # -------------------------------------------------------------------------
+
+    def _unnotify(self, notification: object, refresh: bool = True) -> None:
+        """Override to force a full screen repaint when a toast is dismissed.
+
+        The toast widget is removed from the DOM but the terminal cells it
+        occupied are not always cleared by Textual's normal damage tracking
+        (depends on the backend/protocol). Scheduling a repaint here ensures
+        no ghost rows are left on screen.
+        """
+        super()._unnotify(notification, refresh)  # type: ignore[arg-type]
+        # Schedule the repaint so it runs after the widget removal is processed
+        self.call_later(self.screen.refresh, repaint=True)
 
     @property
     def _displayed_sessions(self) -> list[Session]:

--- a/src/fast_resume/tui/filter_bar.py
+++ b/src/fast_resume/tui/filter_bar.py
@@ -118,11 +118,22 @@ class FilterBar(Horizontal):
         Args:
             agents: Set of agent names that have at least one session.
         """
+        changed = False
         for filter_key, btn in self._filter_buttons.items():
-            if filter_key is None:
-                # "All" button is always visible
-                btn.display = True
-            elif filter_key in agents:
-                btn.display = True
-            else:
-                btn.display = False
+            visible = filter_key is None or filter_key in agents
+            # Use a CSS class instead of toggling .display directly.  Direct
+            # display toggling on a container that holds an ImageWidget can
+            # leave SIXEL/Kitty pixel data as black blocks in the left margin
+            # because the image protocol bytes are not re-sent on re-display.
+            # Hiding via CSS class lets Textual repaint the full layout.
+            if visible and "hidden" in btn.classes:
+                btn.remove_class("hidden")
+                changed = True
+            elif not visible and "hidden" not in btn.classes:
+                btn.add_class("hidden")
+                changed = True
+
+        if changed:
+            # Force a layout pass on the filter bar so the parent repaints
+            # the region previously occupied by hidden buttons.
+            self.refresh(layout=True)

--- a/src/fast_resume/tui/modal.py
+++ b/src/fast_resume/tui/modal.py
@@ -5,69 +5,89 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
-from textual.widgets import Button, Label
+from textual.widgets import Button, Checkbox, Label
 
 from .styles import YOLO_MODAL_CSS
 
 
-class YoloModeModal(ModalScreen[bool]):
-    """Modal to choose yolo mode for resume."""
+class YoloModeModal(ModalScreen[bool | None]):
+    """Modal asking whether to launch the selected session and in what mode.
+
+    Dismisses with:
+        None  -> cancel (stay in TUI, no resume).
+        False -> launch without yolo.
+        True  -> launch with yolo (auto-approve).
+    """
 
     BINDINGS = [
-        Binding("y", "select_yolo", "Yolo Mode", show=False),
-        Binding("n", "select_normal", "Normal", show=False),
-        Binding("escape", "dismiss", "Cancel", show=False),
-        Binding("enter", "select_focused", "Select", show=False),
-        Binding("left", "focus_normal", "Left", show=False),
-        Binding("right", "focus_yolo", "Right", show=False),
+        Binding("escape", "cancel", "Cancel", show=False),
+        Binding("enter", "launch", "Launch", show=False),
+        Binding("space", "toggle_yolo", "Toggle yolo", show=False),
+        Binding("y", "set_yolo_on", "Yolo on", show=False),
+        Binding("n", "set_yolo_off", "Yolo off", show=False),
+        Binding("left", "focus_cancel", "Focus cancel", show=False),
+        Binding("right", "focus_launch", "Focus launch", show=False),
+        # Screen bindings take precedence over the App's priority Tab
+        # binding (which is used for search-input suggestion accept), so
+        # define our own to cycle Cancel ↔ Launch instead of being eaten.
+        Binding("tab", "focus_next", "Next", show=False),
+        Binding("shift+tab", "focus_previous", "Previous", show=False),
     ]
 
     CSS = YOLO_MODAL_CSS
 
     def compose(self) -> ComposeResult:
         with Vertical():
-            yield Label("Resume with yolo mode?", id="title")
+            yield Label("Launch session", id="title")
+            with Horizontal(id="yolo-row"):
+                # Skip the checkbox in the Tab cycle so users can't end up
+                # focused on it and have Enter toggle (Textual's Checkbox
+                # binds enter→toggle by default). Modal-level bindings
+                # (space/y/n) still let users flip it. `can_focus` is set
+                # in on_mount because it's not a constructor kwarg.
+                yield Checkbox("Yolo mode (auto-approve)", id="yolo-checkbox")
             with Horizontal(id="buttons"):
-                yield Button("No", id="normal-btn")
-                yield Button("Yolo", id="yolo-btn")
+                yield Button("Cancel", id="cancel-btn")
+                yield Button("Launch", id="launch-btn", variant="primary")
+            yield Label(
+                "Space/y/n: toggle yolo · Enter: launch · Esc: cancel",
+                id="hint",
+            )
 
     def on_mount(self) -> None:
-        """Focus the first button when modal opens."""
-        self.query_one("#normal-btn", Button).focus()
+        # Skip the checkbox in Tab cycling; modal-level bindings handle toggle.
+        self.query_one("#yolo-checkbox", Checkbox).can_focus = False
+        # Focus Launch by default so plain Enter is the obvious action.
+        self.query_one("#launch-btn", Button).focus()
 
-    def action_toggle_focus(self) -> None:
-        """Toggle focus between the two buttons."""
-        if self.focused and self.focused.id == "yolo-btn":
-            self.query_one("#normal-btn", Button).focus()
-        else:
-            self.query_one("#yolo-btn", Button).focus()
+    def _yolo_value(self) -> bool:
+        return self.query_one("#yolo-checkbox", Checkbox).value
 
-    def action_focus_normal(self) -> None:
-        """Focus the normal button."""
-        self.query_one("#normal-btn", Button).focus()
+    def action_cancel(self) -> None:
+        self.dismiss(None)
 
-    def action_focus_yolo(self) -> None:
-        """Focus the yolo button."""
-        self.query_one("#yolo-btn", Button).focus()
+    def action_launch(self) -> None:
+        self.dismiss(self._yolo_value())
 
-    def action_select_focused(self) -> None:
-        """Select whichever button is currently focused."""
-        focused = self.focused
-        if focused and focused.id == "yolo-btn":
-            self.dismiss(True)
-        else:
-            self.dismiss(False)
+    def action_toggle_yolo(self) -> None:
+        self.query_one("#yolo-checkbox", Checkbox).toggle()
 
-    def action_select_yolo(self) -> None:
-        self.dismiss(True)
+    def action_set_yolo_on(self) -> None:
+        self.query_one("#yolo-checkbox", Checkbox).value = True
 
-    def action_select_normal(self) -> None:
-        self.dismiss(False)
+    def action_set_yolo_off(self) -> None:
+        self.query_one("#yolo-checkbox", Checkbox).value = False
 
-    @on(Button.Pressed, "#yolo-btn")
-    def on_yolo_pressed(self) -> None:
-        self.dismiss(True)
+    def action_focus_cancel(self) -> None:
+        self.query_one("#cancel-btn", Button).focus()
 
-    @on(Button.Pressed, "#normal-btn")
-    def on_normal_pressed(self) -> None:
-        self.dismiss(False)
+    def action_focus_launch(self) -> None:
+        self.query_one("#launch-btn", Button).focus()
+
+    @on(Button.Pressed, "#cancel-btn")
+    def on_cancel_pressed(self) -> None:
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#launch-btn")
+    def on_launch_pressed(self) -> None:
+        self.dismiss(self._yolo_value())

--- a/src/fast_resume/tui/preview.py
+++ b/src/fast_resume/tui/preview.py
@@ -2,42 +2,16 @@
 
 import re
 from io import StringIO
-from pathlib import Path
-from typing import Any
 
-from rich.columns import Columns
 from rich.console import Console, Group, RenderableType
 from rich.markup import escape as escape_markup
 from rich.syntax import Syntax
 from rich.text import Text
 from textual.widgets import Static
-from textual_image.renderable import Image as ImageRenderable
 
 from ..adapters.base import Session
 from ..config import AGENTS
 from .utils import highlight_matches
-
-# Asset paths for agent icons
-ASSETS_DIR = Path(__file__).parent.parent / "assets"
-
-# Cache for agent icon renderables
-_preview_icon_cache: dict[str, Any] = {}
-
-
-def _get_agent_icon(agent: str) -> RenderableType | None:
-    """Get the icon renderable for an agent."""
-    if agent not in _preview_icon_cache:
-        icon_path = ASSETS_DIR / f"{agent}.png"
-        if icon_path.exists():
-            try:
-                _preview_icon_cache[agent] = ImageRenderable(
-                    icon_path, width=2, height=1
-                )
-            except Exception:
-                _preview_icon_cache[agent] = None
-        else:
-            _preview_icon_cache[agent] = None
-    return _preview_icon_cache[agent]
 
 
 class SessionPreview(Static):
@@ -100,11 +74,14 @@ class SessionPreview(Static):
             if len(content) > 5000:
                 preview_text += "..."
 
-        # Get agent config and icon
+        # Get agent config — no inline image per message, badge text only.
+        # Rendering an ImageRenderable inside Columns for every assistant turn
+        # sends inline-image protocol bytes (Kitty/Sixel) that Textual's
+        # compositor cannot erase on refresh, leaving pixel artifacts when
+        # switching between sessions.
         agent_config = AGENTS.get(
             session.agent, {"color": "white", "badge": session.agent}
         )
-        agent_icon = _get_agent_icon(session.agent)
 
         # Build list of renderables
         renderables: list[RenderableType] = []
@@ -117,26 +94,10 @@ class SessionPreview(Static):
             if not msg.strip():
                 continue
 
-            # Detect if this is a user message
             is_user = msg.startswith("» ")
-
-            if is_user:
-                # User message - render as text
-                text = Text()
-                self._render_message(text, msg, query, is_user, agent_config)
-                renderables.append(text)
-            else:
-                # Assistant message - add icon + text
-                if agent_icon is not None:
-                    # Create icon with text on same line using Columns
-                    text = Text()
-                    self._render_message_content(text, msg, query, agent_config)
-                    renderables.append(Columns([agent_icon, text], padding=(0, 1)))
-                else:
-                    # Fallback to badge
-                    text = Text()
-                    self._render_message(text, msg, query, is_user, agent_config)
-                    renderables.append(text)
+            text = Text()
+            self._render_message(text, msg, query, is_user, agent_config)
+            renderables.append(text)
 
         return Group(*renderables)
 

--- a/src/fast_resume/tui/styles.py
+++ b/src/fast_resume/tui/styles.py
@@ -8,7 +8,7 @@ YoloModeModal {
 }
 
 YoloModeModal > Vertical {
-    width: 36;
+    width: 48;
     height: auto;
     background: $surface;
     border: thick $primary 80%;
@@ -19,6 +19,24 @@ YoloModeModal #title {
     text-align: center;
     text-style: bold;
     width: 100%;
+}
+
+YoloModeModal #yolo-row {
+    width: 100%;
+    height: auto;
+    align: center middle;
+    margin-top: 1;
+}
+
+YoloModeModal Checkbox {
+    width: auto;
+    background: transparent;
+    border: none;
+    padding: 0;
+}
+
+YoloModeModal Checkbox:focus {
+    text-style: bold;
 }
 
 YoloModeModal #buttons {
@@ -34,8 +52,21 @@ YoloModeModal Button {
     pointer: pointer;
 }
 
-YoloModeModal Button:focus {
+/* Only the primary action gets the warning highlight on focus, so
+ * Tab-cycling onto Cancel doesn't look like the "do it" button. */
+YoloModeModal #launch-btn:focus {
     background: $warning;
+}
+
+YoloModeModal #cancel-btn:focus {
+    background: $surface-lighten-2;
+}
+
+YoloModeModal #hint {
+    width: 100%;
+    text-align: center;
+    color: $text-muted;
+    margin-top: 1;
 }
 """
 
@@ -108,6 +139,15 @@ Screen {
     width: 100%;
     padding: 0 1;
     margin-bottom: 1;
+    /* With 9+ adapters the bar can exceed an 80-column terminal; let it
+     * scroll horizontally instead of silently clipping the rightmost
+     * buttons. */
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
+.filter-btn.hidden {
+    display: none;
 }
 
 .filter-btn {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -385,3 +385,120 @@ class TestOutputFormatting:
         captured = capsys.readouterr()
         assert "Showing 3 of 3 sessions" in captured.out
         assert "/home/user" in captured.out or "home" in captured.out
+
+
+class TestLaunchBanner:
+    """Tests for the launch banner added in this PR.
+
+    The banner is printed between TUI teardown and agent CLI startup so the
+    transition isn't silent.
+    """
+
+    def test_launch_banner_is_printed(self, cli_runner):
+        """Launch banner shows 'Launching:' followed by the command."""
+        with (
+            patch("fast_resume.cli.run_tui") as mock_run_tui,
+            patch("fast_resume.cli.os.chdir"),
+            patch("fast_resume.cli.os.execvp"),
+        ):
+            mock_run_tui.return_value = (
+                ["claude", "--resume", "abc123"],
+                "/home/user/project",
+            )
+            result = cli_runner.invoke(main, [])
+
+        assert result.exit_code == 0
+        assert "Launching:" in result.output
+        assert "claude" in result.output
+        assert "abc123" in result.output
+
+    def test_launch_banner_not_printed_when_no_resume(self, cli_runner):
+        """No launch banner when TUI exits without selecting a session."""
+        with patch("fast_resume.cli.run_tui") as mock_run_tui:
+            mock_run_tui.return_value = (None, None)
+            result = cli_runner.invoke(main, [])
+
+        assert result.exit_code == 0
+        assert "Launching:" not in result.output
+
+    def test_launch_banner_escapes_rich_markup_in_session_id(self, cli_runner):
+        """Session IDs that look like Rich markup are escaped in the banner."""
+        with (
+            patch("fast_resume.cli.run_tui") as mock_run_tui,
+            patch("fast_resume.cli.os.chdir"),
+            patch("fast_resume.cli.os.execvp"),
+        ):
+            # Session id contains Rich markup characters that must not be
+            # interpreted as markup tags.
+            mock_run_tui.return_value = (
+                ["claude", "--resume", "[bold]evil[/bold]"],
+                "/tmp",
+            )
+            result = cli_runner.invoke(main, [])
+
+        # The output must not render "[bold]" as styling; the literal text
+        # should appear instead (Rich escaping replaces "[" with the escaped
+        # form so the tag shows as plain text on the terminal).
+        assert "Launching:" in result.output
+        # The raw Rich markup tags should NOT appear unescaped in the plain
+        # text output — if escaping worked, "evil" will still be visible but
+        # "[bold]" will be shown literally rather than treated as a tag.
+        assert "evil" in result.output
+
+    def test_oserror_prints_error_message(self, cli_runner):
+        """OSError from os.execvp is caught and an error message is printed."""
+        with (
+            patch("fast_resume.cli.run_tui") as mock_run_tui,
+            patch("fast_resume.cli.os.chdir"),
+            patch("fast_resume.cli.os.execvp", side_effect=OSError("No such file")),
+        ):
+            mock_run_tui.return_value = (
+                ["nonexistent-agent", "--resume", "xyz"],
+                "/tmp",
+            )
+            result = cli_runner.invoke(main, [])
+
+        assert result.exit_code == 1
+        assert "Error" in result.output
+        assert "nonexistent-agent" in result.output
+
+    def test_oserror_exit_code_is_1(self, cli_runner):
+        """Process exits with code 1 when os.execvp raises OSError."""
+        with (
+            patch("fast_resume.cli.run_tui") as mock_run_tui,
+            patch("fast_resume.cli.os.chdir"),
+            patch(
+                "fast_resume.cli.os.execvp", side_effect=OSError("permission denied")
+            ),
+        ):
+            mock_run_tui.return_value = (["claude", "--resume", "x"], None)
+            result = cli_runner.invoke(main, [])
+
+        assert result.exit_code == 1
+
+    def test_oserror_message_mentions_original_error(self, cli_runner):
+        """The OSError message text is included in the printed error."""
+        with (
+            patch("fast_resume.cli.run_tui") as mock_run_tui,
+            patch("fast_resume.cli.os.chdir"),
+            patch(
+                "fast_resume.cli.os.execvp",
+                side_effect=OSError("no such file or directory"),
+            ),
+        ):
+            mock_run_tui.return_value = (["claude", "--resume", "x"], None)
+            result = cli_runner.invoke(main, [])
+
+        assert "no such file or directory" in result.output
+
+    def test_successful_execvp_does_not_exit_with_error(self, cli_runner):
+        """When os.execvp succeeds the exit code is 0 (CliRunner returns 0)."""
+        with (
+            patch("fast_resume.cli.run_tui") as mock_run_tui,
+            patch("fast_resume.cli.os.chdir"),
+            patch("fast_resume.cli.os.execvp"),
+        ):
+            mock_run_tui.return_value = (["claude", "--resume", "ok"], "/tmp")
+            result = cli_runner.invoke(main, [])
+
+        assert result.exit_code == 0

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -311,8 +311,8 @@ class TestEndToEndDataFlow:
             # App should still be running (modal is shown)
             assert integration_app.is_running
 
-            # Press 'n' to select normal mode (no yolo)
-            await pilot.press("n")
+            # Default checkbox is off; press Enter to launch without yolo.
+            await pilot.press("enter")
             await pilot.pause()
 
             # App should have exited after modal selection

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -369,6 +369,17 @@ class TestTantivyFiltering:
         """Create an index with multiple sessions for comprehensive filter testing."""
         index = TantivyIndex(index_path=temp_dir / "filter_test_index")
         now = datetime.now()
+        today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+        def within_today(delta: timedelta) -> datetime:
+            """Clamp `now - delta` to today's calendar day.
+
+            If the test runs shortly after midnight, `now - timedelta(hours=1)`
+            falls into yesterday and breaks date:today filter tests. Clamp it
+            so the timestamp is still ordered before `now` but stays inside
+            today's window.
+            """
+            return max(now - delta, today_start + timedelta(seconds=1))
 
         sessions = [
             # Claude sessions
@@ -377,7 +388,9 @@ class TestTantivyFiltering:
                 agent="claude",
                 title="Fix auth bug",
                 directory="/home/user/web-app",
-                timestamp=now - timedelta(hours=1),  # 1 hour ago
+                timestamp=within_today(
+                    timedelta(hours=1)
+                ),  # 1 hour ago (clamped to today)
                 content="authentication token validation",
                 message_count=5,
                 mtime=1000.0,
@@ -398,7 +411,9 @@ class TestTantivyFiltering:
                 agent="codex",
                 title="Refactor code",
                 directory="/home/user/web-app",
-                timestamp=now - timedelta(hours=2),  # 2 hours ago
+                timestamp=within_today(
+                    timedelta(hours=2)
+                ),  # 2 hours ago (clamped to today)
                 content="refactoring the database layer",
                 message_count=4,
                 mtime=1002.0,
@@ -419,7 +434,9 @@ class TestTantivyFiltering:
                 agent="vibe",
                 title="Create API",
                 directory="/home/user/api-server",
-                timestamp=now - timedelta(minutes=30),  # 30 min ago
+                timestamp=within_today(
+                    timedelta(minutes=30)
+                ),  # 30 min ago (clamped to today)
                 content="REST API endpoint creation",
                 message_count=6,
                 mtime=1004.0,

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -499,6 +499,24 @@ def mock_search_engine(sample_sessions):
     return mock
 
 
+@pytest.fixture(autouse=True)
+def mock_shutil_which_for_tui(request):
+    """Patch shutil.which in app.py so resume commands appear findable by default.
+
+    Tests that specifically want to test the "binary not found" path opt out by
+    including 'path_validation' in their marker or by using their own patch.
+    """
+    # The TestPathValidation tests manage their own shutil.which patch
+    if (
+        request.node.cls is not None
+        and request.node.cls.__name__ == "TestPathValidation"
+    ):
+        yield
+        return
+    with patch("fast_resume.tui.app.shutil.which", return_value="/usr/bin/fake-agent"):
+        yield
+
+
 class TestFastResumeAppBasic:
     """Basic TUI integration tests."""
 
@@ -1080,8 +1098,9 @@ class TestFastResumeAppYoloModal:
                 # App should still be running (modal is shown)
                 assert app.is_running
 
-                # Press 'n' to select normal mode
-                await pilot.press("n")
+                # Default switch state is off; pressing Enter on the launch
+                # button dismisses the modal and exits the TUI without yolo.
+                await pilot.press("enter")
                 await pilot.pause()
 
                 # Now app should have exited
@@ -1174,8 +1193,10 @@ class TestFastResumeAppYoloModal:
                 await pilot.press("enter")
                 await pilot.pause()
 
-                # Press 'y' to select yolo mode
+                # Press 'y' to turn the yolo checkbox on, then Enter to launch
                 await pilot.press("y")
+                await pilot.pause()
+                await pilot.press("enter")
                 await pilot.pause()
 
                 # App should have exited
@@ -1187,8 +1208,8 @@ class TestFastResumeAppYoloModal:
                 assert "--dangerously-skip-permissions" in cmd
 
     @pytest.mark.asyncio
-    async def test_tab_toggles_focus_in_modal(self, sample_sessions):
-        """Test that tab key toggles focus between buttons in yolo modal."""
+    async def test_modal_arrow_keys_move_focus(self, sample_sessions):
+        """Left/Right arrow keys move focus between Cancel and Launch."""
         mock = MagicMock()
         mock.search.return_value = sample_sessions
         mock.get_session_count.return_value = len(sample_sessions)
@@ -1210,23 +1231,55 @@ class TestFastResumeAppYoloModal:
                 await pilot.press("enter")
                 await pilot.pause()
 
-                # Initial focus should be on normal-btn
+                # Initial focus should be on launch-btn (so Enter launches).
                 modal = app.screen
-                assert modal.focused.id == "normal-btn"
+                assert modal.focused is not None
+                assert modal.focused.id == "launch-btn"
 
-                # Press tab to toggle focus to yolo-btn
-                await pilot.press("tab")
+                # Left arrow moves focus to cancel-btn
+                await pilot.press("left")
                 await pilot.pause()
-                assert modal.focused.id == "yolo-btn"
+                assert modal.focused.id == "cancel-btn"
 
-                # Press tab again to toggle back to normal-btn
-                await pilot.press("tab")
+                # Right arrow moves focus back to launch-btn
+                await pilot.press("right")
                 await pilot.pause()
-                assert modal.focused.id == "normal-btn"
+                assert modal.focused.id == "launch-btn"
 
-                # Dismiss modal
+                # Escape cancels (returns None, no resume)
                 await pilot.press("escape")
                 await pilot.pause()
+                assert app.get_resume_command() is None
+
+    @pytest.mark.asyncio
+    async def test_modal_cancel_keeps_tui_open(self, sample_sessions):
+        """Pressing Escape on the modal cancels without exiting the TUI."""
+        mock = MagicMock()
+        mock.search.return_value = sample_sessions
+        mock.get_session_count.return_value = len(sample_sessions)
+        mock._load_from_index.return_value = sample_sessions
+        mock._sessions = sample_sessions
+        mock._streaming_in_progress = False
+        mock.get_sessions_streaming.return_value = (sample_sessions, 0, 0, 0)
+        mock.get_resume_command.return_value = ["claude", "--resume", "session-1"]
+        mock_adapter = MagicMock()
+        mock_adapter.supports_yolo = True
+        mock.get_adapter_for_session.return_value = mock_adapter
+
+        with patch("fast_resume.tui.app.SessionSearch", return_value=mock):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+
+                await pilot.press("enter")  # show modal
+                await pilot.pause()
+                await pilot.press("escape")  # cancel modal
+                await pilot.pause()
+
+                # The modal closes (FastResumeApp's `escape` binding then
+                # exits the app once the modal stack is empty), but no resume
+                # command should have been set.
+                assert app.get_resume_command() is None
 
 
 class TestFastResumeAppRunTui:
@@ -1353,3 +1406,95 @@ class TestKeywordSuggester:
         """Test that suggestions are case insensitive."""
         result = await suggester.get_suggestion("agent:CL")
         assert result == "agent:claude"
+
+
+class TestPathValidation:
+    """Tests for PATH validation before launching agent CLI."""
+
+    @pytest.mark.asyncio
+    async def test_missing_binary_shows_notification_and_keeps_app_running(
+        self, mock_search_engine
+    ):
+        """When the agent binary is not on PATH, show an error notification and
+        do not exit the TUI."""
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ):
+            with patch("fast_resume.tui.app.shutil.which", return_value=None):
+                app = FastResumeApp()
+                async with app.run_test(size=(120, 40)) as pilot:
+                    await pilot.pause()
+
+                    # Press Enter to trigger resume attempt
+                    await pilot.press("enter")
+                    await pilot.pause()
+
+                    # App should still be running (binary not found)
+                    assert app.is_running
+
+                    # _resume_command must not have been set
+                    assert app.get_resume_command() is None
+
+                    # Quit cleanly so run_test context exits without error
+                    await pilot.press("escape")
+
+    @pytest.mark.asyncio
+    async def test_missing_binary_notification_message(self, mock_search_engine):
+        """When the agent binary is missing the notification references the binary
+        name and the agent name."""
+        notifications_posted: list = []
+
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ):
+            with patch("fast_resume.tui.app.shutil.which", return_value=None):
+                app = FastResumeApp()
+                async with app.run_test(size=(120, 40)) as pilot:
+                    await pilot.pause()
+
+                    # Capture notifications via the app's notify method
+                    original_notify = app.notify
+
+                    def capturing_notify(*args, **kwargs):
+                        notifications_posted.append((args, kwargs))
+                        return original_notify(*args, **kwargs)
+
+                    app.notify = capturing_notify  # type: ignore[method-assign]
+
+                    await pilot.press("enter")
+                    await pilot.pause()
+
+                    # Should have shown an error notification
+                    assert len(notifications_posted) >= 1
+                    notif_text = notifications_posted[0][0][0]
+                    # The notification should mention the binary (claude) and severity=error
+                    assert "claude" in notif_text
+                    assert notifications_posted[0][1].get("severity") == "error"
+
+                    await pilot.press("escape")
+
+    @pytest.mark.asyncio
+    async def test_binary_found_exits_normally(self, mock_search_engine):
+        """When the agent binary is on PATH, the TUI exits and sets _resume_command."""
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ):
+            # which returns a real path — binary is found
+            with patch(
+                "fast_resume.tui.app.shutil.which",
+                return_value="/usr/bin/claude",
+            ):
+                app = FastResumeApp()
+                async with app.run_test(size=(120, 40)) as pilot:
+                    await pilot.pause()
+
+                    await pilot.press("enter")
+                    await pilot.pause()
+
+                    # App should have exited
+                    assert not app.is_running
+                    assert app.get_resume_command() == [
+                        "claude",
+                        "--resume",
+                        "session-1",
+                    ]

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1498,3 +1498,617 @@ class TestPathValidation:
                         "--resume",
                         "session-1",
                     ]
+
+    @pytest.mark.asyncio
+    async def test_missing_binary_notification_has_long_timeout(
+        self, mock_search_engine
+    ):
+        """Error notification for missing binary should stay visible long enough."""
+        notifications_posted: list = []
+
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ):
+            with patch("fast_resume.tui.app.shutil.which", return_value=None):
+                app = FastResumeApp()
+                async with app.run_test(size=(120, 40)) as pilot:
+                    await pilot.pause()
+
+                    original_notify = app.notify
+
+                    def capturing_notify(*args, **kwargs):
+                        notifications_posted.append((args, kwargs))
+                        return original_notify(*args, **kwargs)
+
+                    app.notify = capturing_notify  # type: ignore[method-assign]
+
+                    await pilot.press("enter")
+                    await pilot.pause()
+
+                    assert len(notifications_posted) >= 1
+                    # Timeout should be generous so user can read the message
+                    timeout = notifications_posted[0][1].get("timeout", 0)
+                    assert timeout >= 5
+
+                    await pilot.press("escape")
+
+    @pytest.mark.asyncio
+    async def test_resume_command_not_set_on_missing_binary(self, mock_search_engine):
+        """_resume_command stays None when the binary cannot be found."""
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ):
+            with patch("fast_resume.tui.app.shutil.which", return_value=None):
+                app = FastResumeApp()
+                async with app.run_test(size=(120, 40)) as pilot:
+                    await pilot.pause()
+                    await pilot.press("enter")
+                    await pilot.pause()
+
+                    # Command must not be set if we never validated the binary.
+                    assert app._resume_command is None
+
+                    await pilot.press("escape")
+
+
+class TestYoloModalBehavior:
+    """Unit-level integration tests for the redesigned YoloModeModal widget."""
+
+    def _make_yolo_mock(self, sample_sessions):
+        """Build a mock search engine whose adapter supports yolo."""
+        mock = MagicMock()
+        mock.search.return_value = sample_sessions
+        mock.get_session_count.return_value = len(sample_sessions)
+        mock._load_from_index.return_value = sample_sessions
+        mock._sessions = sample_sessions
+        mock._streaming_in_progress = False
+        mock.get_sessions_streaming.return_value = (sample_sessions, 0, 0, 0)
+
+        def _resume_cmd(session, yolo=False):
+            if yolo:
+                return [
+                    "claude",
+                    "--dangerously-skip-permissions",
+                    "--resume",
+                    session.id,
+                ]
+            return ["claude", "--resume", session.id]
+
+        mock.get_resume_command.side_effect = _resume_cmd
+        mock_adapter = MagicMock()
+        mock_adapter.supports_yolo = True
+        mock.get_adapter_for_session.return_value = mock_adapter
+        return mock
+
+    @pytest.mark.asyncio
+    async def test_checkbox_starts_unchecked(self, sample_sessions):
+        """The yolo checkbox is unchecked when the modal first opens."""
+        from fast_resume.tui.modal import YoloModeModal
+        from textual.widgets import Checkbox
+
+        mock = self._make_yolo_mock(sample_sessions)
+        with patch("fast_resume.tui.app.SessionSearch", return_value=mock):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                await pilot.press("enter")  # open modal
+                await pilot.pause()
+
+                modal = app.screen
+                assert isinstance(modal, YoloModeModal)
+                checkbox = modal.query_one("#yolo-checkbox", Checkbox)
+                assert checkbox.value is False
+
+                await pilot.press("escape")
+
+    @pytest.mark.asyncio
+    async def test_space_toggles_checkbox_on(self, sample_sessions):
+        """Pressing Space turns the yolo checkbox on."""
+        from textual.widgets import Checkbox
+
+        mock = self._make_yolo_mock(sample_sessions)
+        with patch("fast_resume.tui.app.SessionSearch", return_value=mock):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                await pilot.press("enter")  # open modal
+                await pilot.pause()
+
+                await pilot.press("space")  # toggle on
+                await pilot.pause()
+
+                modal = app.screen
+                checkbox = modal.query_one("#yolo-checkbox", Checkbox)
+                assert checkbox.value is True
+
+                await pilot.press("escape")
+
+    @pytest.mark.asyncio
+    async def test_space_toggles_checkbox_off(self, sample_sessions):
+        """Pressing Space twice returns the checkbox to unchecked."""
+        from textual.widgets import Checkbox
+
+        mock = self._make_yolo_mock(sample_sessions)
+        with patch("fast_resume.tui.app.SessionSearch", return_value=mock):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                await pilot.press("enter")
+                await pilot.pause()
+
+                await pilot.press("space")  # on
+                await pilot.press("space")  # back off
+                await pilot.pause()
+
+                modal = app.screen
+                checkbox = modal.query_one("#yolo-checkbox", Checkbox)
+                assert checkbox.value is False
+
+                await pilot.press("escape")
+
+    @pytest.mark.asyncio
+    async def test_n_key_turns_yolo_off_after_y(self, sample_sessions):
+        """After turning yolo on with 'y', pressing 'n' turns it off."""
+        from textual.widgets import Checkbox
+
+        mock = self._make_yolo_mock(sample_sessions)
+        with patch("fast_resume.tui.app.SessionSearch", return_value=mock):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                await pilot.press("enter")
+                await pilot.pause()
+
+                await pilot.press("y")  # turn on
+                await pilot.press("n")  # turn off
+                await pilot.pause()
+
+                modal = app.screen
+                checkbox = modal.query_one("#yolo-checkbox", Checkbox)
+                assert checkbox.value is False
+
+                await pilot.press("escape")
+
+    @pytest.mark.asyncio
+    async def test_y_key_turns_yolo_on(self, sample_sessions):
+        """Pressing 'y' while in the modal checks the yolo checkbox."""
+        from textual.widgets import Checkbox
+
+        mock = self._make_yolo_mock(sample_sessions)
+        with patch("fast_resume.tui.app.SessionSearch", return_value=mock):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                await pilot.press("enter")
+                await pilot.pause()
+
+                await pilot.press("y")
+                await pilot.pause()
+
+                modal = app.screen
+                checkbox = modal.query_one("#yolo-checkbox", Checkbox)
+                assert checkbox.value is True
+
+                await pilot.press("escape")
+
+    @pytest.mark.asyncio
+    async def test_enter_launches_with_yolo_state(self, sample_sessions):
+        """Enter dismisses the modal and launches with the current checkbox value."""
+        mock = self._make_yolo_mock(sample_sessions)
+        with patch("fast_resume.tui.app.SessionSearch", return_value=mock):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                await pilot.press("enter")  # open modal
+                await pilot.pause()
+
+                # Turn on yolo then confirm with Enter
+                await pilot.press("y")
+                await pilot.pause()
+                await pilot.press("enter")  # launch
+                await pilot.pause()
+
+                assert not app.is_running
+                cmd = app.get_resume_command()
+                assert cmd is not None
+                assert "--dangerously-skip-permissions" in cmd
+
+    @pytest.mark.asyncio
+    async def test_tab_cycles_focus_between_buttons(self, sample_sessions):
+        """Tab key navigates modal focus; focus stays on a button (not checkbox)."""
+        from fast_resume.tui.modal import YoloModeModal
+        from textual.widgets import Button
+
+        mock = self._make_yolo_mock(sample_sessions)
+        with patch("fast_resume.tui.app.SessionSearch", return_value=mock):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                await pilot.press("enter")
+                await pilot.pause()
+
+                modal = app.screen
+                assert isinstance(modal, YoloModeModal)
+                # Default focus is on launch-btn
+                assert modal.focused is not None
+                assert modal.focused.id == "launch-btn"
+
+                # Tab cycles focus; checkbox is excluded (can_focus=False) so
+                # focus stays on one of the two buttons (exact Textual wrapping
+                # direction is an implementation detail we don't pin).
+                await pilot.press("tab")
+                await pilot.pause()
+                assert isinstance(modal.focused, Button)
+
+                # Left arrow definitively moves focus to cancel-btn.
+                await pilot.press("left")
+                await pilot.pause()
+                assert modal.focused.id == "cancel-btn"
+
+                await pilot.press("escape")
+
+    @pytest.mark.asyncio
+    async def test_cancel_button_click_dismisses_with_none(self, sample_sessions):
+        """Clicking Cancel leaves no resume command set."""
+        mock = self._make_yolo_mock(sample_sessions)
+        with patch("fast_resume.tui.app.SessionSearch", return_value=mock):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                await pilot.press("enter")  # open modal
+                await pilot.pause()
+
+                # Move focus to cancel-btn and press Enter to activate it
+                await pilot.press("left")
+                await pilot.pause()
+                await pilot.press("enter")
+                await pilot.pause()
+
+                assert app.get_resume_command() is None
+
+    @pytest.mark.asyncio
+    async def test_modal_title_is_launch_session(self, sample_sessions):
+        """The modal title text says 'Launch session'."""
+        from fast_resume.tui.modal import YoloModeModal
+        from textual.widgets import Label
+
+        mock = self._make_yolo_mock(sample_sessions)
+        with patch("fast_resume.tui.app.SessionSearch", return_value=mock):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                await pilot.press("enter")
+                await pilot.pause()
+
+                modal = app.screen
+                assert isinstance(modal, YoloModeModal)
+                title = modal.query_one("#title", Label)
+                assert "Launch" in str(title.render())
+
+                await pilot.press("escape")
+
+
+class TestModalGuards:
+    """Tests for the guard conditions that prevent actions while modal is open."""
+
+    def _make_yolo_mock(self, sample_sessions):
+        mock = MagicMock()
+        mock.search.return_value = sample_sessions
+        mock.get_session_count.return_value = len(sample_sessions)
+        mock._load_from_index.return_value = sample_sessions
+        mock._sessions = sample_sessions
+        mock._streaming_in_progress = False
+        mock.get_sessions_streaming.return_value = (sample_sessions, 0, 0, 0)
+        mock.get_resume_command.return_value = ["claude", "--resume", "session-1"]
+        mock_adapter = MagicMock()
+        mock_adapter.supports_yolo = True
+        mock.get_adapter_for_session.return_value = mock_adapter
+        return mock
+
+    @pytest.mark.asyncio
+    async def test_copy_cmd_noop_during_modal(self, sample_sessions):
+        """Pressing 'c' while the yolo modal is open doesn't stack a second modal."""
+        mock = self._make_yolo_mock(sample_sessions)
+        with patch("fast_resume.tui.app.SessionSearch", return_value=mock):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                await pilot.press("enter")  # open modal
+                await pilot.pause()
+
+                screen_before = app.screen
+
+                # Press 'c' which would normally open another modal
+                await pilot.press("c")
+                await pilot.pause()
+
+                # Screen stack should not have grown
+                assert app.screen is screen_before
+                assert len(app.screen_stack) == 2  # app screen + one modal
+
+                await pilot.press("escape")
+
+    @pytest.mark.asyncio
+    async def test_slash_noop_during_modal(self, sample_sessions):
+        """Pressing '/' while the yolo modal is open does not steal focus."""
+        from fast_resume.tui.modal import YoloModeModal
+
+        mock = self._make_yolo_mock(sample_sessions)
+        with patch("fast_resume.tui.app.SessionSearch", return_value=mock):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                await pilot.press("enter")  # open modal
+                await pilot.pause()
+
+                # Modal has focus; pressing '/' should be a no-op
+                await pilot.press("/")
+                await pilot.pause()
+
+                # Modal should still be the active screen
+                assert isinstance(app.screen, YoloModeModal)
+
+                await pilot.press("escape")
+
+    @pytest.mark.asyncio
+    async def test_toggle_preview_noop_during_modal(self, sample_sessions):
+        """Ctrl+` does not toggle show_preview while the modal is active."""
+        mock = self._make_yolo_mock(sample_sessions)
+        with patch("fast_resume.tui.app.SessionSearch", return_value=mock):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+
+                initial_show_preview = app.show_preview
+
+                await pilot.press("enter")  # open modal
+                await pilot.pause()
+
+                await pilot.press("ctrl+grave_accent")  # should be no-op
+                await pilot.pause()
+
+                # show_preview must be unchanged
+                assert app.show_preview == initial_show_preview
+
+                await pilot.press("escape")
+
+    @pytest.mark.asyncio
+    async def test_tab_in_modal_does_not_accept_suggestion(self, sample_sessions):
+        """Tab while modal is open cycles modal buttons, not search-input suggestions."""
+        from fast_resume.tui.modal import YoloModeModal
+
+        mock = self._make_yolo_mock(sample_sessions)
+        with patch("fast_resume.tui.app.SessionSearch", return_value=mock):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                await pilot.press("enter")
+                await pilot.pause()
+
+                # Tab should move focus within the modal, not close it
+                await pilot.press("tab")
+                await pilot.pause()
+
+                assert isinstance(app.screen, YoloModeModal)
+
+                await pilot.press("escape")
+
+
+class TestRefreshPreviewMemoization:
+    """Tests for the _refresh_preview memoization in FastResumeApp."""
+
+    @pytest.mark.asyncio
+    async def test_preview_updated_on_session_change(
+        self, mock_search_engine, sample_sessions
+    ):
+        """Switching to a different session updates the preview."""
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+
+                # App starts with session-1 previewed
+                assert app._previewed_session is not None
+                first_previewed = app._previewed_session
+
+                # Navigate to second session
+                table = app.query_one("#results-table")
+                table.focus()
+                await pilot.press("down")
+                await pilot.pause()
+
+                # Preview should have updated to the new session
+                assert app._previewed_session is not first_previewed
+
+    @pytest.mark.asyncio
+    async def test_preview_not_updated_on_same_session_same_query(
+        self, mock_search_engine, sample_sessions
+    ):
+        """Calling _refresh_preview with the same session+query is a no-op."""
+
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+
+                # Record preview state
+                previewed_after_load = app._previewed_session
+                assert previewed_after_load is not None
+
+                # Call _refresh_preview with the same session and no query change
+                app._refresh_preview(previewed_after_load)
+
+                # The memo guard should prevent _previewed_session from changing
+                assert app._previewed_session is previewed_after_load
+
+    @pytest.mark.asyncio
+    async def test_preview_updated_on_query_change(
+        self, mock_search_engine, sample_sessions
+    ):
+        """When the query changes for the same session, preview refreshes."""
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+
+                session = app._previewed_session
+
+                # Simulate a query change
+                app._current_query = "new-query"
+                app._refresh_preview(session)
+                await pilot.pause()
+
+                # Memo should now reflect the new query
+                assert app._previewed_query == "new-query"
+
+    @pytest.mark.asyncio
+    async def test_refresh_preview_with_none_session_updates_memo(
+        self, mock_search_engine
+    ):
+        """Calling _refresh_preview(None) does not update _previewed_session memo."""
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+
+                # Pass None — the memo guard short-circuits only for non-None
+                # sessions, so calling with None should always pass through.
+                app._refresh_preview(None)
+                await pilot.pause()
+
+                # previewed_session should now be None (we refreshed to empty)
+                assert app._previewed_session is None
+
+
+class TestFilterBarCSSHidden:
+    """Tests for FilterBar.update_agents_with_sessions CSS class approach."""
+
+    @pytest.mark.asyncio
+    async def test_filter_button_hidden_for_agent_with_no_sessions(
+        self, mock_search_engine
+    ):
+        """Filter buttons for agents without sessions get the 'hidden' CSS class."""
+        from fast_resume.tui.filter_bar import FilterBar
+
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+
+                filter_bar = app.query_one(FilterBar)
+                # Update with only claude and vibe present
+                filter_bar.update_agents_with_sessions({"claude", "vibe"})
+                await pilot.pause()
+
+                # codex button should be hidden
+                codex_btn = filter_bar._filter_buttons.get("codex")
+                assert codex_btn is not None
+                assert "hidden" in codex_btn.classes
+
+    @pytest.mark.asyncio
+    async def test_filter_button_visible_for_agent_with_sessions(
+        self, mock_search_engine
+    ):
+        """Filter buttons for agents WITH sessions do NOT have the 'hidden' CSS class."""
+        from fast_resume.tui.filter_bar import FilterBar
+
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+
+                filter_bar = app.query_one(FilterBar)
+                filter_bar.update_agents_with_sessions({"claude", "vibe"})
+                await pilot.pause()
+
+                # claude and vibe buttons should NOT be hidden
+                claude_btn = filter_bar._filter_buttons.get("claude")
+                vibe_btn = filter_bar._filter_buttons.get("vibe")
+                assert claude_btn is not None
+                assert "hidden" not in claude_btn.classes
+                assert vibe_btn is not None
+                assert "hidden" not in vibe_btn.classes
+
+    @pytest.mark.asyncio
+    async def test_all_button_never_hidden(self, mock_search_engine):
+        """The 'All' filter button (key=None) is never hidden."""
+        from fast_resume.tui.filter_bar import FilterBar
+
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+
+                filter_bar = app.query_one(FilterBar)
+                # Pass an empty set — no agents have sessions
+                filter_bar.update_agents_with_sessions(set())
+                await pilot.pause()
+
+                all_btn = filter_bar._filter_buttons.get(None)
+                assert all_btn is not None
+                assert "hidden" not in all_btn.classes
+
+    @pytest.mark.asyncio
+    async def test_hidden_class_removed_when_agent_reappears(self, mock_search_engine):
+        """When an agent gains sessions, its button's 'hidden' class is removed."""
+        from fast_resume.tui.filter_bar import FilterBar
+
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+
+                filter_bar = app.query_one(FilterBar)
+
+                # Hide codex
+                filter_bar.update_agents_with_sessions({"claude"})
+                await pilot.pause()
+                codex_btn = filter_bar._filter_buttons.get("codex")
+                assert "hidden" in codex_btn.classes
+
+                # Now codex has sessions again
+                filter_bar.update_agents_with_sessions({"claude", "codex"})
+                await pilot.pause()
+                assert "hidden" not in codex_btn.classes
+
+    @pytest.mark.asyncio
+    async def test_no_change_when_visibility_already_correct(self, mock_search_engine):
+        """Calling update_agents_with_sessions with unchanged state does nothing."""
+        from fast_resume.tui.filter_bar import FilterBar
+
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+
+                filter_bar = app.query_one(FilterBar)
+
+                # Apply a state
+                filter_bar.update_agents_with_sessions({"claude", "vibe"})
+                await pilot.pause()
+
+                # Patch refresh to detect spurious calls
+                with patch.object(filter_bar, "refresh") as mock_refresh:
+                    # Calling again with the same set must not trigger a refresh
+                    filter_bar.update_agents_with_sessions({"claude", "vibe"})
+                    await pilot.pause()
+
+                mock_refresh.assert_not_called()


### PR DESCRIPTION
Three things. The modal redesign is the opinionated one; happy to discuss before you review the rest.

## "No / Yolo" → Cancel / Launch + checkbox

Pressing `n` in the current prompt means "no yolo" and still launches, but it reads as "no, cancel." Someone new to the tool will press it expecting to back out. The new modal has `[Cancel]` and `[Launch]` buttons with a yolo checkbox; Cancel means cancel, Launch means launch, the checkbox controls the yolo flag. The existing dismissal contract (`None` / `False` / `True`) is unchanged, so all existing callbacks work.

Default focus is `Launch`, so the double-Enter flow still works. `y`/`n`/`Space` toggle the checkbox without moving focus away from Launch. The checkbox is excluded from the Tab cycle (`can_focus = False` set in `on_mount`) because Textual's Checkbox eats Enter to toggle. If it were in the cycle, tabbing to it and pressing Enter would toggle the box rather than launch.

## Preview-pane pixel artifacts

`_build_preview_renderable` was putting the agent icon inside `Columns([icon, text])` for every assistant message. A session with 20 assistant turns wrote 20 inline image sequences to the terminal using Kitty/Sixel/iTerm2 protocol. When the session changed, Textual rewrote the cells but had no way to erase pixels the image protocol had already drawn; they'd linger until the user scrolled or clicked. Removed the `Columns` path; assistant messages now show the text badge (`● claude`). Filter-bar icons are unchanged since they're rendered once at mount, never refreshed mid-session.

## PATH validation

`_do_resume` now runs `shutil.which(resume_cmd[0])` before calling `self.exit()`. Without this, a missing binary means the TUI tears down silently and then `os.execvp` raises in `cli.py` with no context. Now it fires an error toast and keeps the user in the TUI. `cli.py` has a belt-and-suspenders `try/except OSError` around `execvp` for edge cases. A `Launching: <command>` line is printed before execvp so the visual gap between TUI teardown and agent startup isn't empty.

## Other changes in this PR

App-priority bindings (`c`, `/`, `Ctrl+\``) now no-op when the modal is the active screen; without this, pressing `c` during the modal stacked a second modal. `action_quit` routes through `top_screen.action_cancel()` instead of `dismiss(None)`. `FilterBar.update_agents_with_sessions` switches from `btn.display = False` to a `.hidden` CSS class to avoid SIXEL/Kitty pixel artifacts on button re-display. `#filter-container` gets `overflow-x: auto` for narrow terminals.

## Test plan

- [x] `uv run pytest` (399 tests pass; new tests for PATH validation, modal click paths, checkbox toggling, and preview memo; CodeRabbit auto-generated an additional 731-line test suite incorporated here)
- [x] `uv run ruff check . && uv run ruff format --check . && uv run ty check src/`
- [x] Codacy static analysis: 0 new issues
- [x] Manual: Launch modal Tab/arrow/Space/y/n/Enter/Esc all work; pixel artifacts gone after the Columns removal

---

> **AI Disclosure:** Developed with [Claude Code](https://claude.ai/code) assistance. Reviewed and verified by the contributor; all tests pass and key UX changes were manually tested in a live terminal.