### PR TITLE
Update adapter resume commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,15 +131,15 @@ Resume sessions with auto-approve / skip-permissions flags:
 | --------------- | -------------------------------------------- | ------------- |
 | Claude          | `--dangerously-skip-permissions`             | No            |
 | Codex           | `--dangerously-bypass-approvals-and-sandbox` | Yes           |
-| Copilot CLI     | `--allow-all-tools --allow-all-paths`        | No            |
+| Copilot CLI     | `--yolo`                                     | No            |
 | Vibe            | `--auto-approve`                             | Yes           |
 | OpenCode        | _(config-based)_                             | —             |
-| Crush           | _(no CLI resume)_                            | —             |
+| Crush           | `--yolo`                                     | No            |
 | VS Code Copilot | _(n/a)_                                      | —             |
 
 **Auto-detection:** Codex and Vibe store the permissions mode in their session files. Sessions originally started in yolo mode are automatically resumed in yolo mode.
 
-**Interactive prompt:** For agents that support yolo but don't store it (Claude, Copilot CLI), you'll see a modal asking whether to resume in yolo mode. Use Tab to toggle, Enter to confirm.
+**Interactive prompt:** For agents that support yolo but don't store it (Claude, Copilot CLI, Crush), you'll see a modal asking whether to resume in yolo mode. Use Tab to toggle, Enter to confirm.
 
 **Force yolo:** Use `fr --yolo` to skip the prompt and always resume in yolo mode, if supported.
 
@@ -440,11 +440,11 @@ Each adapter returns the appropriate command:
 | -------------- | ------------------------------- | -------------------------------------------------------------- |
 | Claude         | `claude --resume <id>`          | `claude --dangerously-skip-permissions --resume <id>`          |
 | Codex          | `codex resume <id>`             | `codex --dangerously-bypass-approvals-and-sandbox resume <id>` |
-| Copilot CLI    | `copilot --resume <id>`         | `copilot --allow-all-tools --allow-all-paths --resume <id>`    |
+| Copilot CLI    | `copilot --resume <id>`         | `copilot --yolo --resume <id>`                                 |
 | Copilot VSCode | `code <directory>`              | _(no change)_                                                  |
 | OpenCode       | `opencode <dir> --session <id>` | _(no change)_                                                  |
 | Vibe           | `vibe --resume <id>`            | `vibe --auto-approve --resume <id>`                            |
-| Crush          | `crush`                         | _(no change)_                                                  |
+| Crush          | `crush --session <id>`          | `crush --yolo --session <id>`                                  |
 
 ### Performance
 

--- a/src/fast_resume/adapters/copilot.py
+++ b/src/fast_resume/adapters/copilot.py
@@ -187,6 +187,6 @@ class CopilotAdapter(BaseSessionAdapter):
         """Get command to resume a Copilot CLI session."""
         cmd = ["copilot"]
         if yolo:
-            cmd.extend(["--allow-all-tools", "--allow-all-paths"])
+            cmd.append("--yolo")
         cmd.extend(["--resume", session.id])
         return cmd

--- a/src/fast_resume/adapters/crush.py
+++ b/src/fast_resume/adapters/crush.py
@@ -24,7 +24,7 @@ class CrushAdapter:
     name = "crush"
     color = AGENTS["crush"]["color"]
     badge = AGENTS["crush"]["badge"]
-    supports_yolo = False
+    supports_yolo = True
 
     def __init__(self, projects_file: Path | None = None) -> None:
         self._projects_file = (
@@ -301,9 +301,11 @@ class CrushAdapter:
 
     def get_resume_command(self, session: Session, yolo: bool = False) -> list[str]:
         """Get command to resume a Crush session."""
-        # Crush is interactive - it shows a session picker when launched in a project directory
-        # fast-resume changes to session.directory before executing this command
-        return ["crush"]
+        cmd = ["crush"]
+        if yolo:
+            cmd.append("--yolo")
+        cmd.extend(["--session", session.id])
+        return cmd
 
     def get_raw_stats(self) -> RawAdapterStats:
         """Get raw statistics from Crush database files."""

--- a/src/fast_resume/index.py
+++ b/src/fast_resume/index.py
@@ -212,7 +212,8 @@ class TantivyIndex:
         schema = index.schema
         query = tantivy.Query.term_query(schema, "agent", agent_filter)
         # Tantivy requires limit > 0, use count property for total matches
-        return searcher.search(query, limit=1).count  # type: ignore[attr-defined]
+        result = searcher.search(query, limit=1)
+        return int(getattr(result, "count"))
 
     def get_stats(self) -> IndexStats:
         """Get statistics about the index contents."""

--- a/tests/test_copilot_adapter.py
+++ b/tests/test_copilot_adapter.py
@@ -318,6 +318,23 @@ class TestCopilotAdapter:
 
         assert cmd == ["copilot", "--resume", "abc123-def456-ghi789"]
 
+    def test_get_resume_command_with_yolo(self, adapter):
+        """Test resume command generation with yolo flag."""
+        from fast_resume.adapters.base import Session
+
+        session = Session(
+            id="abc123-def456-ghi789",
+            agent="copilot",
+            title="Test",
+            directory="/test",
+            timestamp=datetime.now(),
+            content="",
+        )
+
+        cmd = adapter.get_resume_command(session, yolo=True)
+
+        assert cmd == ["copilot", "--yolo", "--resume", "abc123-def456-ghi789"]
+
     def test_find_sessions(self, temp_dir):
         """Test finding sessions in the session directory."""
         session_dir = temp_dir / "session-state"

--- a/tests/test_crush_adapter.py
+++ b/tests/test_crush_adapter.py
@@ -79,7 +79,7 @@ class TestCrushAdapter:
         assert adapter.name == "crush"
         assert adapter.color is not None
         assert adapter.badge == "crush"
-        assert adapter.supports_yolo is False
+        assert adapter.supports_yolo is True
 
     def test_parse_session_basic(self, adapter, temp_dir):
         """Test parsing a basic Crush session from database."""
@@ -292,8 +292,24 @@ class TestCrushAdapter:
 
         cmd = adapter.get_resume_command(session)
 
-        # Crush just opens in the project directory
-        assert cmd == ["crush"]
+        assert cmd == ["crush", "--session", "session-abc123"]
+
+    def test_get_resume_command_with_yolo(self, adapter):
+        """Test resume command generation with yolo flag."""
+        from fast_resume.adapters.base import Session
+
+        session = Session(
+            id="session-abc123",
+            agent="crush",
+            title="Test",
+            directory="/test/project",
+            timestamp=datetime.now(),
+            content="",
+        )
+
+        cmd = adapter.get_resume_command(session, yolo=True)
+
+        assert cmd == ["crush", "--yolo", "--session", "session-abc123"]
 
     def test_find_sessions_from_projects_file(self, temp_dir):
         """Test finding sessions from projects.json file."""


### PR DESCRIPTION
## Summary

- Update Copilot CLI yolo resumes to use the current `--yolo` flag.
- Resume Crush sessions directly with `--session <id>` and enable Crush yolo resumes with `--yolo`.
- Update adapter tests and README command tables to match the current CLIs.

## Validation

- `uv run pytest`
- Local adapter scan across Claude, Codex, Copilot CLI, Copilot VS Code, Crush, OpenCode, and Vibe session stores with zero parse errors.

## Notes

The existing unstaged `uv.lock` change was left out of this PR.