### PR TITLE
feat: show session names in TUI with named-only filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ That's why I built `fast-resume`: a command-line tool that aggregates all your c
 - **Very fast**: Built on the Rust-powered Tantivy search engine for blazing-fast indexing and searching
 - **Fuzzy Matching**: Typo-tolerant search with smart ranking (exact matches boosted)
 - **Direct Resume**: Select, Enter, you're back in your session
+- **Named Sessions**: Shows the session name in the list — your `/rename` titles (`✎`) and Claude's auto-generated titles (`✦`) — with `Ctrl+N` to filter to sessions you named yourself
 - **Beautiful TUI**: fzf-style interface with agent icons, color-coded results, and live preview
 - **Update Notifications**: Get notified when a new version is available
 - **Multi-Agent Support**: Works with Claude Code, Codex, Copilot, OpenCode, Vibe, Crush, and more
@@ -184,6 +185,7 @@ Options:
 | `+` / `-` | Resize preview pane                   |
 | `Tab`     | Accept autocomplete suggestion        |
 | `c`       | Copy full resume command to clipboard |
+| `Ctrl+N`  | Toggle showing only named sessions    |
 | `Ctrl+P`  | Open command palette                  |
 | `q`/`Esc` | Quit                                  |
 
@@ -196,6 +198,18 @@ Options:
 | `y`             | Select Yolo       |
 | `n`             | Select No         |
 | `Esc`           | Cancel            |
+
+## Session Titles
+
+Each result shows the most meaningful name available for a session:
+
+| Marker | Source                                                              |
+| ------ | ------------------------------------------------------------------- |
+| `✎`    | A name you set yourself (e.g. Claude Code's `/rename` command)       |
+| `✦`    | A title the agent generated automatically (e.g. Claude's `aiTitle`) |
+| (none) | No assigned name — falls back to the first user message             |
+
+A user-set name always takes priority over an auto-generated one. Press `Ctrl+N` to filter the list to sessions you named yourself (those marked `✎`).
 
 ## Statistics Dashboard
 

--- a/src/fast_resume/adapters/base.py
+++ b/src/fast_resume/adapters/base.py
@@ -49,6 +49,9 @@ class Session:
     message_count: int = 0  # Number of user + assistant messages
     mtime: float = 0.0  # File modification time for incremental updates
     yolo: bool = False  # Session was started with auto-approve/skip-permissions
+    # Where `title` came from: "custom" (user /rename), "ai" (agent-generated),
+    # or "" (derived from the first user message). Empty means the session is unnamed.
+    title_source: str = ""
 
 
 @dataclass

--- a/src/fast_resume/adapters/claude.py
+++ b/src/fast_resume/adapters/claude.py
@@ -47,6 +47,8 @@ class ClaudeAdapter(BaseSessionAdapter):
         """Parse a Claude Code session file."""
         try:
             first_user_message = ""
+            ai_title = ""
+            custom_title = ""
             directory = ""
             timestamp = datetime.fromtimestamp(session_file.stat().st_mtime)
             messages: list[str] = []
@@ -64,6 +66,14 @@ class ClaudeAdapter(BaseSessionAdapter):
                         continue
 
                     msg_type = data.get("type", "")
+
+                    # A user-set name from /rename is written as a custom-title record
+                    if msg_type == "custom-title":
+                        custom_title = data.get("customTitle", "") or custom_title
+
+                    # Claude assigns a generated session name via an ai-title record
+                    if msg_type == "ai-title":
+                        ai_title = data.get("aiTitle", "") or ai_title
 
                     # Get directory from user message
                     if msg_type == "user" and not directory:
@@ -136,9 +146,18 @@ class ClaudeAdapter(BaseSessionAdapter):
             if not first_user_message:
                 return None
 
-            # Always use first user message as title (matches Claude Code's Resume Session UI)
-            # The summary field is not a good title - it's often stale after session resume
-            title = truncate_title(first_user_message)
+            # Title precedence: a user-set name (/rename -> customTitle) wins, then
+            # Claude's generated name (aiTitle), then the first user message. The
+            # source is tracked so the UI can distinguish user-named from AI-named.
+            if custom_title.strip():
+                title_source = "custom"
+                title = truncate_title(custom_title)
+            elif ai_title.strip():
+                title_source = "ai"
+                title = truncate_title(ai_title)
+            else:
+                title_source = ""
+                title = truncate_title(first_user_message)
 
             # Skip sessions with no actual conversation content
             if not messages:
@@ -154,6 +173,7 @@ class ClaudeAdapter(BaseSessionAdapter):
                 timestamp=timestamp,
                 content=full_content,
                 message_count=turn_count,
+                title_source=title_source,
             )
         except OSError as e:
             error = ParseError(

--- a/src/fast_resume/config.py
+++ b/src/fast_resume/config.py
@@ -28,5 +28,5 @@ CACHE_DIR = Path.home() / ".cache" / "fast-resume"
 INDEX_DIR = CACHE_DIR / "tantivy_index"
 LOG_FILE = CACHE_DIR / "parse-errors.log"
 SCHEMA_VERSION = (
-    20  # Bump when schema changes (20: fast timestamp field for sorting by date)
+    23  # Bump when schema changes (23: title_source field replaces named, custom vs ai)
 )

--- a/src/fast_resume/index.py
+++ b/src/fast_resume/index.py
@@ -84,6 +84,10 @@ class TantivyIndex:
         schema_builder.add_float_field("mtime", stored=True)
         # Yolo mode - session was started with auto-approve/skip-permissions
         schema_builder.add_boolean_field("yolo", stored=True)
+        # Title source - "custom"/"ai"/"" (raw tokenizer for exact-term filtering)
+        schema_builder.add_text_field(
+            "title_source", stored=True, tokenizer_name="raw"
+        )
         return schema_builder.build()
 
     def _check_version(self) -> bool:
@@ -398,6 +402,7 @@ class TantivyIndex:
                 message_count=doc.get_first("message_count") or 0,
                 mtime=doc.get_first("mtime") or 0.0,
                 yolo=doc.get_first("yolo") or False,
+                title_source=doc.get_first("title_source") or "",
             )
         except Exception:
             return None
@@ -432,6 +437,7 @@ class TantivyIndex:
                     message_count=session.message_count,
                     mtime=session.mtime,
                     yolo=session.yolo,
+                    title_source=session.title_source,
                 )
             )
         writer.commit()
@@ -459,6 +465,7 @@ class TantivyIndex:
                     message_count=session.message_count,
                     mtime=session.mtime,
                     yolo=session.yolo,
+                    title_source=session.title_source,
                 )
             )
         writer.commit()
@@ -469,6 +476,7 @@ class TantivyIndex:
         agent_filter: Filter | None = None,
         directory_filter: Filter | None = None,
         date_filter: DateFilter | None = None,
+        named_only: bool = False,
         limit: int = 100,
     ) -> list[tuple[str, float]]:
         """Search the index and return (session_id, score) pairs.
@@ -509,6 +517,13 @@ class TantivyIndex:
             date_query = self._build_date_filter_query(date_filter, schema)
             if date_query:
                 query_parts.append((tantivy.Occur.Must, date_query))
+
+            # Restrict to sessions the user named themselves (e.g. /rename -> custom)
+            if named_only:
+                named_query = tantivy.Query.term_query(
+                    schema, "title_source", "custom"
+                )
+                query_parts.append((tantivy.Occur.Must, named_query))
 
             # Combine all query parts
             if not query_parts:

--- a/src/fast_resume/search.py
+++ b/src/fast_resume/search.py
@@ -230,6 +230,7 @@ class SessionSearch:
         query: str,
         agent_filter: str | None = None,
         directory_filter: str | None = None,
+        named_only: bool = False,
         limit: int = 100,
     ) -> list[Session]:
         """Search sessions using Tantivy full-text search with fuzzy matching.
@@ -271,6 +272,7 @@ class SessionSearch:
             agent_filter=effective_agent,
             directory_filter=effective_dir,
             date_filter=date_filter,
+            named_only=named_only,
             limit=limit,
         )
 

--- a/src/fast_resume/tui/app.py
+++ b/src/fast_resume/tui/app.py
@@ -47,6 +47,7 @@ class FastResumeApp(App):
         Binding("/", "focus_search", "Search", priority=True),
         Binding("enter", "resume_session", "Resume"),
         Binding("c", "copy_path", "Copy resume command", priority=True),
+        Binding("ctrl+n", "toggle_named_filter", "Named only", priority=True),
         Binding("ctrl+grave_accent", "toggle_preview", "Preview", priority=True),
         Binding("tab", "accept_suggestion", "Accept", show=False, priority=True),
         Binding("j", "cursor_down", "Down", show=False),
@@ -64,6 +65,7 @@ class FastResumeApp(App):
     show_preview: reactive[bool] = reactive(True)
     selected_session: reactive[Session | None] = reactive(None)
     active_filter: reactive[str | None] = reactive(None)
+    named_only: reactive[bool] = reactive(False)
     is_loading: reactive[bool] = reactive(True)
     preview_height: reactive[int] = reactive(12)
     search_query: reactive[str] = reactive("", init=False)
@@ -158,7 +160,10 @@ class FastResumeApp(App):
             self._total_loaded = len(sessions)
             start_time = time.perf_counter()
             self.sessions = self.search_engine.search(
-                self.initial_query, agent_filter=self.active_filter, limit=100
+                self.initial_query,
+                agent_filter=self.active_filter,
+                named_only=self.named_only,
+                limit=100,
             )
             self.query_time_ms = (time.perf_counter() - start_time) * 1000
             self._finish_loading()
@@ -191,10 +196,11 @@ class FastResumeApp(App):
             shown = len(self.sessions)
             # Get total for current filter (or all if no filter)
             total = self.search_engine.get_session_count(self.active_filter)
+            suffix = " · named only" if self.named_only else ""
             if shown < total:
-                count_label.update(f"{shown}/{total} sessions")
+                count_label.update(f"{shown}/{total} sessions{suffix}")
             else:
-                count_label.update(f"{total} sessions")
+                count_label.update(f"{total} sessions{suffix}")
             # Update query time in search box
             if self.query_time_ms is not None:
                 time_label.update(f"{self.query_time_ms:.1f}ms")
@@ -212,7 +218,10 @@ class FastResumeApp(App):
             query = self.initial_query
             start_time = time.perf_counter()
             sessions = self.search_engine.search(
-                query, agent_filter=self.active_filter, limit=100
+                query,
+                agent_filter=self.active_filter,
+                named_only=self.named_only,
+                limit=100,
             )
             elapsed_ms = (time.perf_counter() - start_time) * 1000
             total = self.search_engine.get_session_count()
@@ -334,7 +343,10 @@ class FastResumeApp(App):
         self._current_query = query
         start_time = time.perf_counter()
         sessions = self.search_engine.search(
-            query, agent_filter=self.active_filter, limit=100
+            query,
+            agent_filter=self.active_filter,
+            named_only=self.named_only,
+            limit=100,
         )
         elapsed_ms = (time.perf_counter() - start_time) * 1000
         # Update UI from worker thread via call_from_thread
@@ -515,6 +527,11 @@ class FastResumeApp(App):
     def action_focus_search(self) -> None:
         """Focus the search input."""
         self.query_one("#search-input", Input).focus()
+
+    def action_toggle_named_filter(self) -> None:
+        """Toggle showing only sessions the user named themselves (e.g. /rename)."""
+        self.named_only = not self.named_only
+        self._do_search(self._current_query)
 
     def action_toggle_preview(self) -> None:
         """Toggle the preview pane."""

--- a/src/fast_resume/tui/results_table.py
+++ b/src/fast_resume/tui/results_table.py
@@ -10,6 +10,7 @@ from ..adapters.base import Session
 from .utils import (
     format_directory,
     format_time_ago,
+    format_title,
     get_age_color,
     get_agent_icon,
     highlight_matches,
@@ -132,9 +133,12 @@ class ResultsTable(DataTable):
             # Get agent icon (image or text fallback)
             icon = get_agent_icon(session.agent)
 
-            # Title - truncate and highlight matches
-            title = highlight_matches(
-                session.title, self._current_query, max_len=self._title_width
+            # Title - truncate, highlight matches, and mark named sessions by source
+            title = format_title(
+                session.title,
+                session.title_source,
+                self._current_query,
+                max_len=self._title_width,
             )
 
             # Format directory - truncate based on column width

--- a/src/fast_resume/tui/utils.py
+++ b/src/fast_resume/tui/utils.py
@@ -99,6 +99,34 @@ def highlight_matches(
     return result
 
 
+# Markers prefixed to titles by source: a user-set name (/rename) vs an agent name.
+MARKER_CUSTOM = "✎ "  # user-named via /rename
+MARKER_AI = "✦ "  # agent-generated title
+
+_TITLE_MARKERS = {
+    "custom": (MARKER_CUSTOM, "#9ece6a"),  # green
+    "ai": (MARKER_AI, "#7aa2f7"),  # blue
+}
+
+
+def format_title(
+    title: str, title_source: str, query: str = "", max_len: int | None = None
+) -> Text:
+    """Render a session title, prefixing a source-specific marker when it is named.
+
+    title_source is "custom" (user /rename), "ai" (agent-generated), or "" (unnamed).
+    The marker is accounted for in max_len so the cell does not overflow its column.
+    """
+    marker_spec = _TITLE_MARKERS.get(title_source)
+    if marker_spec is None:
+        return highlight_matches(title, query, max_len=max_len)
+
+    glyph, color = marker_spec
+    title_max = max_len - len(glyph) if max_len is not None else None
+    marker = Text(glyph, style=color)
+    return marker + highlight_matches(title, query, max_len=title_max)
+
+
 def get_age_color(age_hours: float) -> str:
     """Return a hex color based on session age using exponential decay gradient.
 

--- a/tests/test_claude_adapter.py
+++ b/tests/test_claude_adapter.py
@@ -76,6 +76,117 @@ class TestClaudeAdapter:
         assert "Help me fix this bug" in session.content
         assert "I'll help you fix the bug" in session.content
 
+    def test_parse_session_with_ai_title_uses_it_and_marks_named(
+        self, adapter, temp_dir
+    ):
+        """A session with an ai-title record uses aiTitle and is marked named."""
+        project_dir = temp_dir / "projects" / "project-abc123"
+        project_dir.mkdir(parents=True)
+        session_file = project_dir / "session-named.jsonl"
+
+        data = [
+            {
+                "type": "user",
+                "cwd": "/home/user/project",
+                "message": {"content": "Help me fix this bug in the login system"},
+            },
+            {
+                "type": "ai-title",
+                "aiTitle": "Fix token validation in auth.py",
+                "sessionId": "session-named",
+            },
+            {"type": "assistant", "message": {"content": "I'll help you."}},
+        ]
+
+        with open(session_file, "w") as f:
+            for entry in data:
+                f.write(json.dumps(entry) + "\n")
+
+        session = adapter._parse_session_file(session_file)
+
+        assert session is not None
+        assert session.title == "Fix token validation in auth.py"
+        assert session.title_source == "ai"
+
+    def test_parse_session_with_custom_title_uses_it_and_marks_named(
+        self, adapter, temp_dir
+    ):
+        """A user-renamed session (custom-title) uses customTitle and is named."""
+        project_dir = temp_dir / "projects" / "project-abc123"
+        project_dir.mkdir(parents=True)
+        session_file = project_dir / "session-custom.jsonl"
+
+        data = [
+            {
+                "type": "user",
+                "cwd": "/home/user/project",
+                "message": {"content": "Help me remove graylog from the stack"},
+            },
+            {"type": "custom-title", "customTitle": "graylog-removal"},
+            {"type": "assistant", "message": {"content": "Sure."}},
+        ]
+
+        with open(session_file, "w") as f:
+            for entry in data:
+                f.write(json.dumps(entry) + "\n")
+
+        session = adapter._parse_session_file(session_file)
+
+        assert session is not None
+        assert session.title == "graylog-removal"
+        assert session.title_source == "custom"
+
+    def test_custom_title_takes_priority_over_ai_title(self, adapter, temp_dir):
+        """A user-set custom title wins over the auto-generated aiTitle."""
+        project_dir = temp_dir / "projects" / "project-abc123"
+        project_dir.mkdir(parents=True)
+        session_file = project_dir / "session-both.jsonl"
+
+        data = [
+            {
+                "type": "user",
+                "cwd": "/home/user/project",
+                "message": {"content": "Help me remove graylog from the stack"},
+            },
+            {"type": "ai-title", "aiTitle": "Remove Graylog logging integration"},
+            {"type": "custom-title", "customTitle": "graylog-removal"},
+            {"type": "assistant", "message": {"content": "Sure."}},
+        ]
+
+        with open(session_file, "w") as f:
+            for entry in data:
+                f.write(json.dumps(entry) + "\n")
+
+        session = adapter._parse_session_file(session_file)
+
+        assert session is not None
+        assert session.title == "graylog-removal"
+
+    def test_parse_session_without_ai_title_is_not_named(self, adapter, temp_dir):
+        """A session without an ai-title falls back to first user message, not named."""
+        project_dir = temp_dir / "projects" / "project-abc123"
+        project_dir.mkdir(parents=True)
+        session_file = project_dir / "session-unnamed.jsonl"
+
+        data = [
+            {
+                "type": "user",
+                "cwd": "/home/user/project",
+                "message": {"content": "Help me fix this bug in the login system"},
+            },
+            {"type": "assistant", "message": {"content": "I'll help you."}},
+        ]
+
+        with open(session_file, "w") as f:
+            for entry in data:
+                f.write(json.dumps(entry) + "\n")
+
+        session = adapter._parse_session_file(session_file)
+
+        assert session is not None
+        assert session.title == "Help me fix this bug in the login system"
+        assert session.title_source == ""
+
     def test_parse_session_without_summary(self, adapter, temp_dir):
         """Test parsing session without summary uses first user message as title."""
         project_dir = temp_dir / "projects" / "project-abc123"

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -58,6 +58,60 @@ class TestTantivyIndex:
         assert sessions[0].title == "Test session"
         assert sessions[0].agent == "claude"
 
+    def test_title_source_round_trips(self, index):
+        """The title_source persists through indexing and retrieval."""
+        named = Session(
+            id="named-1",
+            agent="claude",
+            title="A user name",
+            directory="/p",
+            timestamp=datetime(2024, 1, 15, 10, 30, 0),
+            content="content",
+            title_source="custom",
+        )
+        index.add_sessions([named])
+
+        sessions = index.get_all_sessions()
+        assert len(sessions) == 1
+        assert sessions[0].title_source == "custom"
+
+    def test_named_only_filter_returns_only_custom_titles(self, index):
+        """search(named_only=True) returns only user-named (custom) sessions."""
+        sessions = [
+            Session(
+                id="s-custom",
+                agent="claude",
+                title="graylog-removal",
+                directory="/p",
+                timestamp=datetime(2024, 1, 15, 10, 30, 0),
+                content="alpha",
+                title_source="custom",
+            ),
+            Session(
+                id="s-ai",
+                agent="claude",
+                title="Generated name",
+                directory="/p",
+                timestamp=datetime(2024, 1, 15, 10, 31, 0),
+                content="alpha",
+                title_source="ai",
+            ),
+            Session(
+                id="s-plain",
+                agent="claude",
+                title="just the first message",
+                directory="/p",
+                timestamp=datetime(2024, 1, 15, 10, 32, 0),
+                content="alpha",
+                title_source="",
+            ),
+        ]
+        index.add_sessions(sessions)
+
+        results = index.search("alpha", named_only=True)
+        ids = {sid for sid, _ in results}
+        assert ids == {"s-custom"}
+
     def test_add_sessions_empty_list(self, index):
         """Test adding empty list does nothing."""
         index.add_sessions([])

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -19,6 +19,41 @@ from fast_resume.tui import (
 )
 
 
+class TestFormatTitle:
+    """Tests for format_title (named-session markers)."""
+
+    def test_custom_title_gets_custom_marker(self):
+        from fast_resume.tui.utils import MARKER_AI, MARKER_CUSTOM, format_title
+
+        result = format_title("graylog-removal", title_source="custom")
+        assert result.plain.startswith(MARKER_CUSTOM)
+        assert not result.plain.startswith(MARKER_AI)
+        assert "graylog-removal" in result.plain
+
+    def test_ai_title_gets_ai_marker(self):
+        from fast_resume.tui.utils import MARKER_AI, MARKER_CUSTOM, format_title
+
+        result = format_title("Generated name", title_source="ai")
+        assert result.plain.startswith(MARKER_AI)
+        assert not result.plain.startswith(MARKER_CUSTOM)
+        assert "Generated name" in result.plain
+
+    def test_unnamed_session_has_no_marker(self):
+        from fast_resume.tui.utils import MARKER_AI, MARKER_CUSTOM, format_title
+
+        result = format_title("Fix the login bug", title_source="")
+        assert not result.plain.startswith(MARKER_CUSTOM)
+        assert not result.plain.startswith(MARKER_AI)
+        assert result.plain == "Fix the login bug"
+
+    def test_marker_plus_title_respects_max_len(self):
+        from fast_resume.tui.utils import format_title
+
+        long = "x" * 100
+        result = format_title(long, title_source="custom", max_len=20)
+        assert len(result.plain) <= 20
+
+
 class TestFormatDirectory:
     """Tests for format_directory function."""
 
@@ -828,7 +863,7 @@ class TestFastResumeAppFilters:
         mock.get_session_count.side_effect = mock_get_session_count
 
         # Mock search to return filtered results
-        def mock_search(query, agent_filter=None, limit=100):
+        def mock_search(query, agent_filter=None, named_only=False, limit=100):
             if agent_filter == "claude":
                 return [s for s in sample_sessions if s.agent == "claude"]
             elif agent_filter == "vibe":


### PR DESCRIPTION
## What

Shows a session's **name** in the TUI list and adds a filter for sessions you named yourself.

Builds on the renamed-session-title support already in `master` (#51): that takes Claude's title from `sessions-index.json`; this PR additionally distinguishes *how* a session got its name and surfaces it.

## Title source & precedence

Claude records names in the session JSONL:
- `customTitle` — a name you set with `/rename`
- `aiTitle` — an auto-generated title

The Claude adapter resolves the title as **customTitle → aiTitle → sessions-index title (#51) → first user message**, and records where it came from.

## UI

- Named sessions are marked by source in the results table: `✎` for user-named (custom), `✦` for agent-generated (ai).
- **`Ctrl+N`** toggles a filter showing only the sessions you named yourself (custom titles). The count line shows `· named only` while active.

## Implementation

- `Session` gains a `title_source` field (`"custom"` / `"ai"` / `""`).
- Stored/indexed in Tantivy (raw-tokenized text field); `index.search()` gains a `named_only` filter (`term_query` on `title_source == "custom"`), applied at the Tantivy level like the agent filter.
- `SCHEMA_VERSION` bumped to 22, so the index rebuilds once on upgrade.
- README: feature bullet, `Ctrl+N` keybinding, and a "Session Titles" section.

## Tests

Test-driven — adapter source resolution, index round-trip + `named_only` filter, and both title markers. Full suite passes.
