### PR TITLE
feat: remember preview pane size and cap it at 80% of the view

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ Options:
 | `Ctrl+P`  | Open command palette                  |
 | `q`/`Esc` | Quit                                  |
 
+The preview pane size you set with `+` / `-` is remembered across sessions.
+
 ### Yolo Mode Modal
 
 | Key             | Action            |

--- a/src/fast_resume/config.py
+++ b/src/fast_resume/config.py
@@ -25,6 +25,7 @@ COPILOT_DIR = Path.home() / ".copilot" / "session-state"
 
 # Storage location
 CACHE_DIR = Path.home() / ".cache" / "fast-resume"
+CONFIG_DIR = Path.home() / ".config" / "fast-resume"
 INDEX_DIR = CACHE_DIR / "tantivy_index"
 LOG_FILE = CACHE_DIR / "parse-errors.log"
 SCHEMA_VERSION = (

--- a/src/fast_resume/settings.py
+++ b/src/fast_resume/settings.py
@@ -1,0 +1,40 @@
+"""Persistent user settings for fast-resume.
+
+Settings are stored as a small JSON file in the cache directory. Reads and writes
+are best-effort: a missing or corrupt file falls back to defaults, and write
+failures are silently ignored so the TUI never breaks over a settings problem.
+"""
+
+import json
+from pathlib import Path
+
+from .config import CACHE_DIR
+
+SETTINGS_FILE = CACHE_DIR / "settings.json"
+
+# Default values for all known settings. Loaded settings are merged on top of
+# these, so missing keys always resolve to a sensible default.
+DEFAULTS: dict = {
+    "preview_height": 12,
+}
+
+
+def load_settings(path: Path = SETTINGS_FILE) -> dict:
+    """Load user settings, falling back to defaults for missing/invalid data."""
+    merged = dict(DEFAULTS)
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return merged
+    if isinstance(data, dict):
+        merged.update(data)
+    return merged
+
+
+def save_settings(settings: dict, path: Path = SETTINGS_FILE) -> None:
+    """Persist user settings to disk (best-effort)."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(settings))
+    except OSError:
+        pass

--- a/src/fast_resume/settings.py
+++ b/src/fast_resume/settings.py
@@ -1,16 +1,19 @@
 """Persistent user settings for fast-resume.
 
-Settings are stored as a small JSON file in the cache directory. Reads and writes
-are best-effort: a missing or corrupt file falls back to defaults, and write
-failures are silently ignored so the TUI never breaks over a settings problem.
+Settings are stored as a small JSON file in the config directory. Reads and
+writes are best-effort: a missing or corrupt file falls back to defaults, and
+write failures are silently ignored so the TUI never breaks over a settings
+problem.
 """
 
 import json
 from pathlib import Path
 
-from .config import CACHE_DIR
+from .config import CACHE_DIR, CONFIG_DIR
 
-SETTINGS_FILE = CACHE_DIR / "settings.json"
+SETTINGS_FILE = CONFIG_DIR / "settings.json"
+# Settings originally lived in the cache directory; migrated on first load.
+LEGACY_SETTINGS_FILE = CACHE_DIR / "settings.json"
 
 # Default values for all known settings. Loaded settings are merged on top of
 # these, so missing keys always resolve to a sensible default.
@@ -19,8 +22,21 @@ DEFAULTS: dict = {
 }
 
 
+def _migrate_legacy_settings() -> None:
+    """Move the settings file from the old cache-dir location (best-effort)."""
+    if SETTINGS_FILE.exists() or not LEGACY_SETTINGS_FILE.exists():
+        return
+    try:
+        SETTINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        LEGACY_SETTINGS_FILE.rename(SETTINGS_FILE)
+    except OSError:
+        pass
+
+
 def load_settings(path: Path = SETTINGS_FILE) -> dict:
     """Load user settings, falling back to defaults for missing/invalid data."""
+    if path == SETTINGS_FILE:
+        _migrate_legacy_settings()
     merged = dict(DEFAULTS)
     try:
         data = json.loads(path.read_text())

--- a/src/fast_resume/tui/app.py
+++ b/src/fast_resume/tui/app.py
@@ -6,7 +6,7 @@ import shlex
 import time
 from collections.abc import Callable
 
-from textual import on, work
+from textual import events, on, work
 from textual.app import App, ComposeResult
 from textual.css.query import NoMatches
 from textual.binding import Binding
@@ -42,9 +42,9 @@ class FastResumeApp(App):
 
     CSS = APP_CSS
 
-    # Preview pane height bounds (rows)
+    # Preview pane height: a minimum in rows and a ceiling as a fraction of the view.
     PREVIEW_MIN_HEIGHT = 6
-    PREVIEW_MAX_HEIGHT = 30
+    PREVIEW_MAX_FRACTION = 0.8
 
     BINDINGS = [
         Binding("escape", "quit", "Quit", priority=True),
@@ -137,12 +137,11 @@ class FastResumeApp(App):
         # Set initial filter state from agent_filter parameter
         self.active_filter = self.agent_filter
 
-        # Restore persisted preview pane height
+        # Restore persisted preview pane height (the 80%-of-view ceiling is
+        # enforced by on_resize once the real view size is known).
         saved_height = self._settings.get("preview_height", self.preview_height)
         if isinstance(saved_height, int):
-            self.preview_height = max(
-                self.PREVIEW_MIN_HEIGHT, min(self.PREVIEW_MAX_HEIGHT, saved_height)
-            )
+            self.preview_height = max(self.PREVIEW_MIN_HEIGHT, saved_height)
             self._apply_preview_height()
 
         # Focus search input
@@ -564,10 +563,20 @@ class FastResumeApp(App):
         for _ in range(10):
             table.action_cursor_up()
 
+    def _max_preview_height(self, view_height: int | None = None) -> int:
+        """Preview height ceiling: 80% of the view height, floored at the minimum.
+
+        Pass view_height when the app's own size isn't current yet (e.g. while
+        handling a resize event, where self.size still holds the old value).
+        """
+        height = self.size.height if view_height is None else view_height
+        return max(self.PREVIEW_MIN_HEIGHT, int(height * self.PREVIEW_MAX_FRACTION))
+
     def action_increase_preview(self) -> None:
-        """Increase preview pane height."""
-        if self.preview_height < self.PREVIEW_MAX_HEIGHT:
-            self.preview_height += 3
+        """Increase preview pane height, up to 80% of the view."""
+        max_height = self._max_preview_height()
+        if self.preview_height < max_height:
+            self.preview_height = min(self.preview_height + 3, max_height)
             self._apply_preview_height()
             self._persist_preview_height()
 
@@ -577,6 +586,16 @@ class FastResumeApp(App):
             self.preview_height -= 3
             self._apply_preview_height()
             self._persist_preview_height()
+
+    def on_resize(self, event: events.Resize) -> None:
+        """Clamp the preview height when the window shrinks below its 80% ceiling."""
+        max_height = self._max_preview_height(event.size.height)
+        if self.preview_height > max_height:
+            self.preview_height = max_height
+            try:
+                self._apply_preview_height()
+            except NoMatches:
+                pass  # Layout not ready yet; on_mount will apply it.
 
     def _apply_preview_height(self) -> None:
         """Apply the current preview height to the container."""

--- a/src/fast_resume/tui/app.py
+++ b/src/fast_resume/tui/app.py
@@ -19,6 +19,7 @@ from .. import __version__
 from ..adapters.base import ParseError, Session
 from ..config import LOG_FILE
 from ..search import SessionSearch
+from ..settings import load_settings, save_settings
 from .filter_bar import FILTER_KEYS, FilterBar
 from .modal import YoloModeModal
 from .preview import SessionPreview
@@ -39,6 +40,10 @@ class FastResumeApp(App):
     SUB_TITLE = "Session manager"
 
     CSS = APP_CSS
+
+    # Preview pane height bounds (rows)
+    PREVIEW_MIN_HEIGHT = 6
+    PREVIEW_MAX_HEIGHT = 30
 
     BINDINGS = [
         Binding("escape", "quit", "Quit", priority=True),
@@ -92,6 +97,7 @@ class FastResumeApp(App):
         self._search_timer: Timer | None = None
         self._available_update: str | None = None
         self._syncing_filter: bool = False  # Prevent infinite loops during sync
+        self._settings = load_settings()
 
     def compose(self) -> ComposeResult:
         """Create child widgets."""
@@ -129,6 +135,14 @@ class FastResumeApp(App):
         """Set up the app when mounted."""
         # Set initial filter state from agent_filter parameter
         self.active_filter = self.agent_filter
+
+        # Restore persisted preview pane height
+        saved_height = self._settings.get("preview_height", self.preview_height)
+        if isinstance(saved_height, int):
+            self.preview_height = max(
+                self.PREVIEW_MIN_HEIGHT, min(self.PREVIEW_MAX_HEIGHT, saved_height)
+            )
+            self._apply_preview_height()
 
         # Focus search input
         self.query_one("#search-input", Input).focus()
@@ -551,20 +565,27 @@ class FastResumeApp(App):
 
     def action_increase_preview(self) -> None:
         """Increase preview pane height."""
-        if self.preview_height < 30:
+        if self.preview_height < self.PREVIEW_MAX_HEIGHT:
             self.preview_height += 3
             self._apply_preview_height()
+            self._persist_preview_height()
 
     def action_decrease_preview(self) -> None:
         """Decrease preview pane height."""
-        if self.preview_height > 6:
+        if self.preview_height > self.PREVIEW_MIN_HEIGHT:
             self.preview_height -= 3
             self._apply_preview_height()
+            self._persist_preview_height()
 
     def _apply_preview_height(self) -> None:
         """Apply the current preview height to the container."""
         preview_container = self.query_one("#preview-container")
         preview_container.styles.height = self.preview_height
+
+    def _persist_preview_height(self) -> None:
+        """Remember the preview pane height across sessions."""
+        self._settings["preview_height"] = self.preview_height
+        save_settings(self._settings)
 
     def _set_filter(self, agent: str | None) -> None:
         """Set the agent filter and refresh results, syncing query string."""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -35,3 +35,49 @@ class TestSettings:
         path = temp_dir / "nested" / "dir" / "settings.json"
         save_settings({"preview_height": 9}, path=path)
         assert load_settings(path=path)["preview_height"] == 9
+
+
+class TestLegacyMigration:
+    """Tests for migrating settings.json from the old cache-dir location."""
+
+    def _patch_paths(self, monkeypatch, temp_dir):
+        import fast_resume.settings as settings_mod
+
+        new = temp_dir / "config" / "settings.json"
+        legacy = temp_dir / "cache" / "settings.json"
+        monkeypatch.setattr(settings_mod, "SETTINGS_FILE", new)
+        monkeypatch.setattr(settings_mod, "LEGACY_SETTINGS_FILE", legacy)
+        return new, legacy
+
+    def test_legacy_file_is_moved_to_config_dir(self, temp_dir, monkeypatch):
+        from fast_resume.settings import _migrate_legacy_settings
+
+        new, legacy = self._patch_paths(monkeypatch, temp_dir)
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text('{"preview_height": 25}')
+
+        _migrate_legacy_settings()
+
+        assert not legacy.exists()
+        assert load_settings(path=new)["preview_height"] == 25
+
+    def test_existing_config_file_is_not_overwritten(self, temp_dir, monkeypatch):
+        from fast_resume.settings import _migrate_legacy_settings
+
+        new, legacy = self._patch_paths(monkeypatch, temp_dir)
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text('{"preview_height": 25}')
+        new.parent.mkdir(parents=True)
+        new.write_text('{"preview_height": 30}')
+
+        _migrate_legacy_settings()
+
+        assert load_settings(path=new)["preview_height"] == 30
+        assert legacy.exists()
+
+    def test_no_legacy_file_is_a_noop(self, temp_dir, monkeypatch):
+        from fast_resume.settings import _migrate_legacy_settings
+
+        new, legacy = self._patch_paths(monkeypatch, temp_dir)
+        _migrate_legacy_settings()
+        assert not new.exists()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,37 @@
+"""Tests for persistent user settings."""
+
+from fast_resume.settings import load_settings, save_settings
+
+
+class TestSettings:
+    """Tests for load_settings / save_settings."""
+
+    def test_save_then_load_round_trips(self, temp_dir):
+        path = temp_dir / "settings.json"
+        save_settings({"preview_height": 21}, path=path)
+
+        loaded = load_settings(path=path)
+        assert loaded["preview_height"] == 21
+
+    def test_load_missing_file_returns_defaults(self, temp_dir):
+        path = temp_dir / "does-not-exist.json"
+        loaded = load_settings(path=path)
+        assert loaded["preview_height"] == 12
+
+    def test_load_corrupt_file_returns_defaults(self, temp_dir):
+        path = temp_dir / "settings.json"
+        path.write_text("{ not valid json")
+        loaded = load_settings(path=path)
+        assert loaded["preview_height"] == 12
+
+    def test_load_merges_unknown_keys_with_defaults(self, temp_dir):
+        path = temp_dir / "settings.json"
+        save_settings({"something_else": "x"}, path=path)
+        loaded = load_settings(path=path)
+        # Missing known keys fall back to defaults
+        assert loaded["preview_height"] == 12
+
+    def test_save_creates_parent_directory(self, temp_dir):
+        path = temp_dir / "nested" / "dir" / "settings.json"
+        save_settings({"preview_height": 9}, path=path)
+        assert load_settings(path=path)["preview_height"] == 9

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -516,6 +516,41 @@ class TestFastResumeAppBasic:
                 assert app.is_running
 
     @pytest.mark.asyncio
+    async def test_restores_persisted_preview_height(self, mock_search_engine):
+        """A persisted preview height is restored when the app starts."""
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ), patch(
+            "fast_resume.tui.app.load_settings",
+            return_value={"preview_height": 21},
+        ):
+            app = FastResumeApp(no_version_check=True)
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                assert app.preview_height == 21
+
+    @pytest.mark.asyncio
+    async def test_resizing_preview_persists_height(self, mock_search_engine):
+        """Resizing the preview pane saves the new height to settings."""
+        save_mock = MagicMock()
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ), patch(
+            "fast_resume.tui.app.load_settings",
+            return_value={"preview_height": 12},
+        ), patch("fast_resume.tui.app.save_settings", save_mock):
+            app = FastResumeApp(no_version_check=True)
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                app.action_increase_preview()
+                await pilot.pause()
+
+        assert app.preview_height == 15
+        save_mock.assert_called()
+        saved = save_mock.call_args[0][0]
+        assert saved["preview_height"] == 15
+
+    @pytest.mark.asyncio
     async def test_no_version_check_skips_update_check(self, mock_search_engine):
         """Test that no_version_check=True skips the version check."""
         with patch(
@@ -884,7 +919,10 @@ class TestFastResumeAppPreview:
         """Test that preview height can be adjusted."""
         with patch(
             "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
-        ):
+        ), patch(
+            "fast_resume.tui.app.load_settings",
+            return_value={"preview_height": 12},
+        ), patch("fast_resume.tui.app.save_settings"):
             app = FastResumeApp()
             async with app.run_test(size=(120, 40)) as pilot:
                 await pilot.pause()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -944,6 +944,57 @@ class TestFastResumeAppPreview:
                 await pilot.pause()
                 assert app.preview_height < initial_height
 
+    @pytest.mark.asyncio
+    async def test_max_preview_height_is_80_percent_of_view(self, mock_search_engine):
+        """The preview height ceiling is 80% of the view height."""
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ), patch(
+            "fast_resume.tui.app.load_settings", return_value={"preview_height": 12}
+        ), patch("fast_resume.tui.app.save_settings"):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                assert app._max_preview_height() == 32  # int(40 * 0.8)
+
+    @pytest.mark.asyncio
+    async def test_increase_preview_caps_at_80_percent(self, mock_search_engine):
+        """Pressing + repeatedly never grows the preview past 80% of the view."""
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ), patch(
+            "fast_resume.tui.app.load_settings", return_value={"preview_height": 12}
+        ), patch("fast_resume.tui.app.save_settings"):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                app.query_one("#results-table").focus()
+                await pilot.pause()
+                for _ in range(20):
+                    await pilot.press("equals")
+                await pilot.pause()
+                assert app.preview_height == 32
+
+    @pytest.mark.asyncio
+    async def test_shrinking_window_clamps_preview_height(self, mock_search_engine):
+        """Resizing the window smaller clamps the preview to 80% of the new view."""
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ), patch(
+            "fast_resume.tui.app.load_settings", return_value={"preview_height": 12}
+        ), patch("fast_resume.tui.app.save_settings"):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                app.preview_height = 30
+                app._apply_preview_height()
+
+                await pilot.resize_terminal(120, 10)
+                await pilot.pause()
+
+                # 80% of 10 == 8; the oversized preview must be clamped down
+                assert app.preview_height == 8
+
 
 class TestFastResumeAppResumeCommand:
     """Tests for resume command functionality."""


### PR DESCRIPTION
## What

The preview pane height (set with `+` / `-`) is now **remembered between sessions**, and its maximum is **80% of the view height**, re-clamped when the window is resized.

## Implementation

- New `settings.py`: a small JSON store at `~/.cache/fast-resume/settings.json` with best-effort `load_settings` / `save_settings` (missing or corrupt file falls back to defaults; write failures are ignored so a settings problem can never break the TUI).
- The app loads the saved height on mount and saves it whenever the pane is resized.
- **Max height = 80% of the view** (`PREVIEW_MAX_FRACTION = 0.8`, floored at `PREVIEW_MIN_HEIGHT`) instead of a fixed row count; `+` caps at that ceiling.
- **`on_resize` clamps** the height down when the window shrinks below the new ceiling (it reads the new size from the resize event, since `self.size` isn't updated yet at that point).
- README: a note under the keybindings table.

The settings store is generic (a keyed dict), so future preferences can be added without new plumbing.

## Tests

Test-driven — settings store (round-trip, missing/corrupt file, key merge, parent-dir creation), height restored on launch, resize persists, max is 80% of view, `+` caps at it, and shrinking the window clamps the height. Full suite passes.
