### PR TITLE
fix: silence textual_image cell-size warning on VTE terminals

### DIFF
--- a/src/fast_resume/__init__.py
+++ b/src/fast_resume/__init__.py
@@ -1,5 +1,13 @@
 """fast-resume: Fuzzy finder for coding agent session history."""
 
+import logging
 from importlib.metadata import version
+
+# textual_image probes the terminal for cell size at import time and logs a
+# WARNING + traceback when the terminal can't answer (e.g. VTE terminals such as
+# Terminator or GNOME Terminal). This must run before any submodule imports
+# textual_image, so it lives here rather than in setup_logging(). The library
+# falls back to default sizes, so the message is not actionable.
+logging.getLogger("textual_image").setLevel(logging.ERROR)
 
 __version__ = version("fast-resume")

--- a/src/fast_resume/logging_config.py
+++ b/src/fast_resume/logging_config.py
@@ -17,11 +17,6 @@ def setup_logging() -> None:
     # Ensure cache directory exists
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
-    # Silence textual_image's noisy WARNING (with traceback) emitted when the
-    # terminal can't report cell size - e.g. VTE terminals like Terminator or
-    # GNOME Terminal. It falls back to default sizes, so this is not actionable.
-    logging.getLogger("textual_image").setLevel(logging.ERROR)
-
     # Configure parse error logger
     parse_logger.setLevel(logging.WARNING)
 

--- a/src/fast_resume/logging_config.py
+++ b/src/fast_resume/logging_config.py
@@ -17,6 +17,11 @@ def setup_logging() -> None:
     # Ensure cache directory exists
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
+    # Silence textual_image's noisy WARNING (with traceback) emitted when the
+    # terminal can't report cell size - e.g. VTE terminals like Terminator or
+    # GNOME Terminal. It falls back to default sizes, so this is not actionable.
+    logging.getLogger("textual_image").setLevel(logging.ERROR)
+
     # Configure parse error logger
     parse_logger.setLevel(logging.WARNING)
 

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,24 +1,22 @@
-"""Tests for logging configuration."""
+"""Tests for early logging configuration."""
 
+import importlib
 import logging
 
-from fast_resume.logging_config import setup_logging
 
+def test_textual_image_logger_silenced_on_package_import():
+    """Importing the package raises the textual_image logger to ERROR.
 
-def test_setup_logging_silences_textual_image_warning():
-    """textual_image's logger is raised to ERROR to suppress the cell-size warning.
-
-    On terminals that cannot report cell size (e.g. VTE terminals), textual_image
-    logs a WARNING with a traceback that surfaces on exit. We silence it since the
-    library falls back gracefully.
+    textual_image probes the terminal for cell size at import time (in
+    textual_image.widget) and logs a WARNING + traceback when the terminal can't
+    answer (e.g. VTE terminals like Terminator). The package must silence it
+    before any submodule imports textual_image, so the fix lives in
+    fast_resume/__init__.py rather than in setup_logging() (which runs too late).
     """
-    # Start from a clean slate so we observe setup_logging's effect.
+    import fast_resume
+
     logging.getLogger("textual_image").setLevel(logging.NOTSET)
+    importlib.reload(fast_resume)
 
-    setup_logging()
-
-    assert logging.getLogger("textual_image").level == logging.ERROR
-    # A WARNING from a child logger is therefore suppressed.
-    assert not logging.getLogger("textual_image._terminal").isEnabledFor(
-        logging.WARNING
-    )
+    terminal_logger = logging.getLogger("textual_image._terminal")
+    assert not terminal_logger.isEnabledFor(logging.WARNING)

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,24 @@
+"""Tests for logging configuration."""
+
+import logging
+
+from fast_resume.logging_config import setup_logging
+
+
+def test_setup_logging_silences_textual_image_warning():
+    """textual_image's logger is raised to ERROR to suppress the cell-size warning.
+
+    On terminals that cannot report cell size (e.g. VTE terminals), textual_image
+    logs a WARNING with a traceback that surfaces on exit. We silence it since the
+    library falls back gracefully.
+    """
+    # Start from a clean slate so we observe setup_logging's effect.
+    logging.getLogger("textual_image").setLevel(logging.NOTSET)
+
+    setup_logging()
+
+    assert logging.getLogger("textual_image").level == logging.ERROR
+    # A WARNING from a child logger is therefore suppressed.
+    assert not logging.getLogger("textual_image._terminal").isEnabledFor(
+        logging.WARNING
+    )


### PR DESCRIPTION
## What

Silences a noisy `WARNING` + traceback that `textual_image` prints on terminals that can't report cell size.

## Why

`textual_image` determines cell pixel size via an `ioctl` and, failing that, a terminal escape-sequence query. On VTE-based terminals (Terminator, GNOME Terminal, xfce4-terminal, …) neither is supported, so the query times out:

```
Failed to get cell size via escape sequence, assuming VT340 sizes
...
TimeoutError: Timeout waiting for data
```

The library catches this and falls back to default VT340 sizes — harmless — but logs it at `WARNING` with `exc_info`. The probe runs **at import time** (`textual_image/widget/__init__.py` calls `get_cell_size()` at module load), so the message appears on startup.

## Change

Raise the `textual_image` logger to `ERROR` in `fast_resume/__init__.py`:

```python
logging.getLogger("textual_image").setLevel(logging.ERROR)
```

It must live in the package `__init__` (not `setup_logging()`): the import-time probe fires as soon as a submodule imports `textual_image`, which happens before `setup_logging()` is called. `__init__.py` runs before any submodule, so the level is set first. Keeps real errors, drops the non-actionable warning.

## Tests

`tests/test_logging_config.py` reloads the package and asserts the `textual_image` logger is no longer enabled for `WARNING`. Full suite passes.
