### PR TITLE
Support renamed coding agent session titles

### DIFF
--- a/src/fast_resume/adapters/claude.py
+++ b/src/fast_resume/adapters/claude.py
@@ -19,6 +19,9 @@ class ClaudeAdapter(BaseSessionAdapter):
 
     def __init__(self, sessions_dir: Path | None = None) -> None:
         self._sessions_dir = sessions_dir if sessions_dir is not None else CLAUDE_DIR
+        self._project_indexes: dict[
+            Path, tuple[float, dict[str, tuple[str, float]]]
+        ] = {}
 
     def find_sessions(self) -> list[Session]:
         """Find all Claude Code sessions."""
@@ -136,9 +139,10 @@ class ClaudeAdapter(BaseSessionAdapter):
             if not first_user_message:
                 return None
 
-            # Always use first user message as title (matches Claude Code's Resume Session UI)
-            # The summary field is not a good title - it's often stale after session resume
-            title = truncate_title(first_user_message)
+            # Prefer Claude's session-list title when available. This is where
+            # /rename stores the display name; older sessions may not have one.
+            title_source = self._get_index_title(session_file) or first_user_message
+            title = truncate_title(title_source)
 
             # Skip sessions with no actual conversation content
             if not messages:
@@ -182,6 +186,75 @@ class ClaudeAdapter(BaseSessionAdapter):
                 on_error(error)
             return None
 
+    def _get_project_index_mtime(self, project_dir: Path) -> float:
+        """Return the mtime of a Claude project sessions-index file."""
+        try:
+            return (project_dir / "sessions-index.json").stat().st_mtime
+        except OSError:
+            return 0.0
+
+    def _parse_index_timestamp(self, value: str) -> float:
+        """Parse a Claude sessions-index ISO timestamp to a unix timestamp."""
+        if not value:
+            return 0.0
+
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return 0.0
+
+    def _load_project_index(self, project_dir: Path) -> dict[str, tuple[str, float]]:
+        """Load Claude session titles from a project's sessions-index.json."""
+        index_mtime = self._get_project_index_mtime(project_dir)
+        cached = self._project_indexes.get(project_dir)
+        if cached and cached[0] == index_mtime:
+            return cached[1]
+
+        session_titles: dict[str, tuple[str, float]] = {}
+        if index_mtime:
+            try:
+                with open(project_dir / "sessions-index.json", "rb") as f:
+                    data = orjson.loads(f.read())
+
+                entries = data.get("entries", [])
+                if isinstance(entries, list):
+                    for entry in entries:
+                        if not isinstance(entry, dict):
+                            continue
+
+                        session_id = entry.get("sessionId", "")
+                        summary = entry.get("summary", "")
+                        if not isinstance(session_id, str) or not session_id:
+                            continue
+                        if not isinstance(summary, str) or not summary.strip():
+                            continue
+
+                        entry_mtime = index_mtime
+                        modified = entry.get("modified", "")
+                        if isinstance(modified, str):
+                            entry_mtime = max(
+                                entry_mtime, self._parse_index_timestamp(modified)
+                            )
+
+                        file_mtime = entry.get("fileMtime")
+                        if isinstance(file_mtime, int | float):
+                            entry_mtime = max(entry_mtime, file_mtime / 1000)
+
+                        session_titles[session_id] = (
+                            summary.strip(),
+                            entry_mtime,
+                        )
+            except OSError, orjson.JSONDecodeError:
+                session_titles = {}
+
+        self._project_indexes[project_dir] = (index_mtime, session_titles)
+        return session_titles
+
+    def _get_index_title(self, session_file: Path) -> str:
+        """Return Claude's indexed session title for a session file."""
+        entry = self._load_project_index(session_file.parent).get(session_file.stem)
+        return entry[0] if entry else ""
+
     def _scan_session_files(self) -> dict[str, tuple[Path, float]]:
         """Scan all Claude Code session files."""
         current_files: dict[str, tuple[Path, float]] = {}
@@ -189,6 +262,8 @@ class ClaudeAdapter(BaseSessionAdapter):
         for project_dir in self._sessions_dir.iterdir():
             if not project_dir.is_dir():
                 continue
+
+            project_index = self._load_project_index(project_dir)
 
             for session_file in project_dir.glob("*.jsonl"):
                 if session_file.name.startswith("agent-"):
@@ -199,6 +274,9 @@ class ClaudeAdapter(BaseSessionAdapter):
                 except OSError:
                     continue
                 session_id = session_file.stem
+                index_entry = project_index.get(session_id)
+                if index_entry:
+                    mtime = max(mtime, index_entry[1])
                 current_files[session_id] = (session_file, mtime)
 
         return current_files

--- a/src/fast_resume/adapters/codex.py
+++ b/src/fast_resume/adapters/codex.py
@@ -17,8 +17,17 @@ class CodexAdapter(BaseSessionAdapter):
     badge = AGENTS["codex"]["badge"]
     supports_yolo = True
 
-    def __init__(self, sessions_dir: Path | None = None) -> None:
+    def __init__(
+        self, sessions_dir: Path | None = None, session_index_file: Path | None = None
+    ) -> None:
         self._sessions_dir = sessions_dir if sessions_dir is not None else CODEX_DIR
+        self._session_index_file = (
+            session_index_file
+            if session_index_file is not None
+            else self._sessions_dir.parent / "session_index.jsonl"
+        )
+        self._session_index_mtime: float | None = None
+        self._session_index: dict[str, tuple[str, float]] = {}
 
     def find_sessions(self) -> list[Session]:
         """Find all Codex CLI sessions."""
@@ -127,8 +136,10 @@ class CodexAdapter(BaseSessionAdapter):
             if not user_prompts:
                 return None
 
-            # Generate title from first actual user prompt (80-char hard truncate)
-            title = truncate_title(user_prompts[0], max_length=80, word_break=False)
+            # Prefer Codex's renamed thread name when available, otherwise fall
+            # back to the first actual user prompt (80-char hard truncate).
+            title_source = self._get_thread_name(session_id) or user_prompts[0]
+            title = truncate_title(title_source, max_length=80, word_break=False)
 
             full_content = "\n\n".join(messages)
 
@@ -169,6 +180,70 @@ class CodexAdapter(BaseSessionAdapter):
                 on_error(error)
             return None
 
+    def _get_session_index_mtime(self) -> float:
+        """Return the mtime of Codex's session index, or 0 when unavailable."""
+        try:
+            return self._session_index_file.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    def _parse_index_timestamp(self, value: str) -> float:
+        """Parse Codex session_index updated_at timestamp to a unix timestamp."""
+        if not value:
+            return self._get_session_index_mtime()
+
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return self._get_session_index_mtime()
+
+    def _load_session_index(self) -> dict[str, tuple[str, float]]:
+        """Load Codex thread names from ~/.codex/session_index.jsonl."""
+        index_mtime = self._get_session_index_mtime()
+        if self._session_index_mtime == index_mtime:
+            return self._session_index
+
+        session_index: dict[str, tuple[str, float]] = {}
+        if index_mtime:
+            try:
+                with open(self._session_index_file, "rb") as f:
+                    for line in f:
+                        if not line.strip():
+                            continue
+                        try:
+                            data = orjson.loads(line)
+                        except orjson.JSONDecodeError:
+                            continue
+
+                        session_id = data.get("id", "")
+                        thread_name = data.get("thread_name", "")
+                        if not isinstance(session_id, str) or not session_id:
+                            continue
+                        if not isinstance(thread_name, str) or not thread_name.strip():
+                            continue
+
+                        updated_at = data.get("updated_at", "")
+                        updated_mtime = (
+                            self._parse_index_timestamp(updated_at)
+                            if isinstance(updated_at, str)
+                            else index_mtime
+                        )
+                        session_index[session_id] = (
+                            thread_name.strip(),
+                            updated_mtime,
+                        )
+            except OSError:
+                session_index = {}
+
+        self._session_index_mtime = index_mtime
+        self._session_index = session_index
+        return self._session_index
+
+    def _get_thread_name(self, session_id: str) -> str:
+        """Return the Codex thread name for a session ID, if available."""
+        entry = self._load_session_index().get(session_id)
+        return entry[0] if entry else ""
+
     def _get_session_id_from_file(self, session_file: Path) -> str:
         """Extract session ID from file content or filename."""
         # Try to get ID from session_meta in file content first
@@ -199,6 +274,7 @@ class CodexAdapter(BaseSessionAdapter):
     def _scan_session_files(self) -> dict[str, tuple[Path, float]]:
         """Scan all Codex CLI session files."""
         current_files: dict[str, tuple[Path, float]] = {}
+        session_index = self._load_session_index()
 
         for session_file in self._sessions_dir.rglob("*.jsonl"):
             try:
@@ -206,6 +282,9 @@ class CodexAdapter(BaseSessionAdapter):
             except OSError:
                 continue
             session_id = self._get_session_id_from_file(session_file)
+            index_entry = session_index.get(session_id)
+            if index_entry:
+                mtime = max(mtime, index_entry[1])
             current_files[session_id] = (session_file, mtime)
 
         return current_files

--- a/src/fast_resume/adapters/copilot.py
+++ b/src/fast_resume/adapters/copilot.py
@@ -41,6 +41,7 @@ class CopilotAdapter(BaseSessionAdapter):
         try:
             session_id = self._fallback_session_id(session_file)
             first_user_message = ""
+            session_title = ""
             directory = ""
             timestamp = datetime.fromtimestamp(session_file.stat().st_mtime)
             messages: list[str] = []
@@ -75,6 +76,12 @@ class CopilotAdapter(BaseSessionAdapter):
                             if match:
                                 directory = match.group(1)
 
+                    # Get title from /rename or generated session name updates
+                    if msg_type == "session.title_changed":
+                        title = data.get("title", "")
+                        if isinstance(title, str) and title.strip():
+                            session_title = title.strip()
+
                     # Process user messages
                     if msg_type == "user.message":
                         content = data.get("content", "")
@@ -95,8 +102,7 @@ class CopilotAdapter(BaseSessionAdapter):
             if not first_user_message:
                 return None
 
-            # Use first user message as title
-            title = truncate_title(first_user_message)
+            title = truncate_title(session_title or first_user_message)
 
             # Skip sessions with no actual conversation content
             if not messages:

--- a/src/fast_resume/config.py
+++ b/src/fast_resume/config.py
@@ -28,5 +28,5 @@ CACHE_DIR = Path.home() / ".cache" / "fast-resume"
 INDEX_DIR = CACHE_DIR / "tantivy_index"
 LOG_FILE = CACHE_DIR / "parse-errors.log"
 SCHEMA_VERSION = (
-    20  # Bump when schema changes (20: fast timestamp field for sorting by date)
+    21  # Bump when indexed session data semantics change (21: indexed thread titles)
 )

--- a/tests/test_claude_adapter.py
+++ b/tests/test_claude_adapter.py
@@ -1,6 +1,7 @@
 """Tests for Claude Code session adapter."""
 
 import json
+import os
 from datetime import datetime
 
 import pytest
@@ -104,6 +105,51 @@ class TestClaudeAdapter:
 
         assert session is not None
         assert "Implement a new feature" in session.title
+
+    def test_parse_session_prefers_sessions_index_summary(self, temp_dir):
+        """Test that Claude /rename titles from sessions-index are used."""
+        project_dir = temp_dir / "projects" / "project-abc123"
+        project_dir.mkdir(parents=True)
+        session_file = project_dir / "session-rename.jsonl"
+
+        data = [
+            {
+                "type": "user",
+                "cwd": "/home/user/project",
+                "message": {"content": "Original first prompt for this session"},
+            },
+            {
+                "type": "assistant",
+                "message": {"content": "Response"},
+            },
+        ]
+
+        with open(session_file, "w") as f:
+            for entry in data:
+                f.write(json.dumps(entry) + "\n")
+
+        with open(project_dir / "sessions-index.json", "w") as f:
+            json.dump(
+                {
+                    "version": 1,
+                    "entries": [
+                        {
+                            "sessionId": "session-rename",
+                            "summary": "Renamed Claude thread",
+                            "modified": "2026-06-03T16:11:02.882Z",
+                            "fileMtime": 1780503062882,
+                        }
+                    ],
+                },
+                f,
+            )
+
+        adapter = ClaudeAdapter(sessions_dir=temp_dir / "projects")
+        session = adapter._parse_session_file(session_file)
+
+        assert session is not None
+        assert session.title == "Renamed Claude thread"
+        assert "Original first prompt" in session.content
 
     def test_parse_session_with_list_content(self, adapter, temp_dir):
         """Test parsing session with list-style content (multi-part messages)."""
@@ -340,3 +386,54 @@ class TestClaudeAdapter:
 
         assert len(files) == 1
         assert "session-001" in files
+
+    def test_incremental_detects_sessions_index_title_update(self, temp_dir):
+        """Test that sessions-index mtime triggers Claude title refreshes."""
+        project_dir = temp_dir / "project-abc"
+        project_dir.mkdir(parents=True)
+        session_file = project_dir / "session-rename.jsonl"
+        sessions_index_file = project_dir / "sessions-index.json"
+
+        data = [
+            {
+                "type": "user",
+                "cwd": "/test",
+                "message": {"content": "Original first prompt for this session"},
+            },
+            {"type": "assistant", "message": {"content": "Response"}},
+        ]
+
+        with open(session_file, "w") as f:
+            for entry in data:
+                f.write(json.dumps(entry) + "\n")
+
+        session_file_mtime = 1700000000.0
+        os.utime(session_file, (session_file_mtime, session_file_mtime))
+
+        with open(sessions_index_file, "w") as f:
+            json.dump(
+                {
+                    "version": 1,
+                    "entries": [
+                        {
+                            "sessionId": "session-rename",
+                            "summary": "Updated Claude title",
+                            "modified": "2023-01-01T00:00:00.000Z",
+                            "fileMtime": int(session_file_mtime * 1000),
+                        }
+                    ],
+                },
+                f,
+            )
+        index_mtime = session_file_mtime + 10
+        os.utime(sessions_index_file, (index_mtime, index_mtime))
+
+        adapter = ClaudeAdapter(sessions_dir=temp_dir)
+        new_or_modified, deleted_ids = adapter.find_sessions_incremental(
+            {"session-rename": (session_file_mtime, "claude")}
+        )
+
+        assert deleted_ids == []
+        assert len(new_or_modified) == 1
+        assert new_or_modified[0].title == "Updated Claude title"
+        assert new_or_modified[0].mtime == index_mtime

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -1,6 +1,7 @@
 """Tests for Codex CLI session adapter."""
 
 import json
+import os
 from datetime import datetime
 
 import pytest
@@ -111,6 +112,49 @@ class TestCodexAdapter:
         assert "First prompt" in session.title
         assert "First prompt" in session.content
         assert "Second prompt" in session.content
+
+    def test_parse_session_prefers_thread_name_from_session_index(self, temp_dir):
+        """Test that renamed Codex thread names are used as session titles."""
+        sessions_dir = temp_dir / "sessions"
+        sessions_dir.mkdir()
+        session_file = sessions_dir / "session.jsonl"
+        session_index_file = temp_dir / "session_index.jsonl"
+
+        data = [
+            {"type": "session_meta", "payload": {"id": "test123", "cwd": "/test"}},
+            {
+                "type": "event_msg",
+                "payload": {
+                    "type": "user_message",
+                    "message": "Original first prompt",
+                },
+            },
+        ]
+
+        with open(session_file, "w") as f:
+            for entry in data:
+                f.write(json.dumps(entry) + "\n")
+
+        with open(session_index_file, "w") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "id": "test123",
+                        "thread_name": "Renamed thread title",
+                        "updated_at": "2026-06-03T16:11:02.882926Z",
+                    }
+                )
+                + "\n"
+            )
+
+        adapter = CodexAdapter(
+            sessions_dir=sessions_dir, session_index_file=session_index_file
+        )
+        session = adapter._parse_session_file(session_file)
+
+        assert session is not None
+        assert session.title == "Renamed thread title"
+        assert "Original first prompt" in session.content
 
     def test_parse_session_skips_environment_context(self, adapter, temp_dir):
         """Test that environment context messages are skipped in content."""
@@ -324,3 +368,52 @@ class TestCodexAdapter:
 
         assert len(files) == 1
         assert "valid123" in files
+
+    def test_incremental_detects_thread_name_update(self, temp_dir):
+        """Test that session_index updated_at triggers Codex title refreshes."""
+        sessions_dir = temp_dir / "sessions"
+        sessions_dir.mkdir()
+        session_file = sessions_dir / "session.jsonl"
+        session_index_file = temp_dir / "session_index.jsonl"
+
+        data = [
+            {"type": "session_meta", "payload": {"id": "test123", "cwd": "/test"}},
+            {
+                "type": "event_msg",
+                "payload": {
+                    "type": "user_message",
+                    "message": "Original first prompt",
+                },
+            },
+        ]
+
+        with open(session_file, "w") as f:
+            for entry in data:
+                f.write(json.dumps(entry) + "\n")
+
+        session_file_mtime = 1700000000.0
+        os.utime(session_file, (session_file_mtime, session_file_mtime))
+
+        with open(session_index_file, "w") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "id": "test123",
+                        "thread_name": "Updated thread title",
+                        "updated_at": "2024-01-01T00:00:00Z",
+                    }
+                )
+                + "\n"
+            )
+
+        adapter = CodexAdapter(
+            sessions_dir=sessions_dir, session_index_file=session_index_file
+        )
+        new_or_modified, deleted_ids = adapter.find_sessions_incremental(
+            {"test123": (session_file_mtime, "codex")}
+        )
+
+        assert deleted_ids == []
+        assert len(new_or_modified) == 1
+        assert new_or_modified[0].title == "Updated thread title"
+        assert new_or_modified[0].mtime > session_file_mtime

--- a/tests/test_copilot_adapter.py
+++ b/tests/test_copilot_adapter.py
@@ -99,6 +99,80 @@ class TestCopilotAdapter:
         assert "Help me implement a REST API endpoint" in session.content
         assert "I'll help you create a REST API endpoint" in session.content
 
+    def test_parse_session_prefers_title_changed_event(self, adapter, temp_dir):
+        """Test parsing a Copilot session title from /rename events."""
+        session_dir = temp_dir / "session-state"
+        session_dir.mkdir(parents=True)
+        session_file = session_dir / "renamed-session.jsonl"
+
+        data = [
+            {
+                "type": "session.start",
+                "data": {"sessionId": "renamed-session-id"},
+            },
+            {
+                "type": "session.title_changed",
+                "data": {"title": "Renamed Copilot Session"},
+            },
+            {
+                "type": "user.message",
+                "data": {"content": "The first user message should not become title"},
+            },
+            {
+                "type": "assistant.message",
+                "data": {"content": "Response"},
+            },
+        ]
+
+        with open(session_file, "w") as f:
+            for entry in data:
+                f.write(json.dumps(entry) + "\n")
+
+        session = adapter._parse_session_file(session_file)
+
+        assert session is not None
+        assert session.id == "renamed-session-id"
+        assert session.title == "Renamed Copilot Session"
+        assert "The first user message should not become title" in session.content
+
+    def test_parse_session_uses_last_title_changed_event(self, adapter, temp_dir):
+        """Test that later Copilot title changes replace earlier ones."""
+        session_dir = temp_dir / "session-state"
+        session_dir.mkdir(parents=True)
+        session_file = session_dir / "renamed-again-session.jsonl"
+
+        data = [
+            {
+                "type": "session.start",
+                "data": {"sessionId": "renamed-again-session-id"},
+            },
+            {
+                "type": "session.title_changed",
+                "data": {"title": "Initial Generated Title"},
+            },
+            {
+                "type": "user.message",
+                "data": {"content": "A prompt that keeps the session non-empty"},
+            },
+            {
+                "type": "session.title_changed",
+                "data": {"title": "Manual Rename Wins"},
+            },
+            {
+                "type": "assistant.message",
+                "data": {"content": "Response"},
+            },
+        ]
+
+        with open(session_file, "w") as f:
+            for entry in data:
+                f.write(json.dumps(entry) + "\n")
+
+        session = adapter._parse_session_file(session_file)
+
+        assert session is not None
+        assert session.title == "Manual Rename Wins"
+
     def test_parse_session_extracts_session_id(self, adapter, temp_dir):
         """Test that session ID is extracted from session.start."""
         session_dir = temp_dir / "session-state"


### PR DESCRIPTION
## Summary

Adds renamed-session title support for Codex, Claude Code, and Copilot CLI adapters.

## Details

- Codex now reads `session_index.jsonl` and uses `thread_name` when available.
- Claude now reads project `sessions-index.json` summaries, where `/rename` stores display names.
- Copilot CLI now uses the latest `session.title_changed` event title.
- Incremental scans account for external title indexes for Codex and Claude so title-only changes are refreshed.
- Bumps the cache schema version so existing indexes rebuild with the new title semantics.
