### PR TITLE
Detect install source for update instructions

### DIFF
--- a/src/fast_resume/tui/__init__.py
+++ b/src/fast_resume/tui/__init__.py
@@ -1,6 +1,7 @@
 """TUI package for fast-resume."""
 
 from .. import __version__
+from ..update import update_instruction
 from .app import FastResumeApp
 from .search_input import KeywordSuggester
 from .modal import YoloModeModal
@@ -35,7 +36,7 @@ def run_tui(
     if not no_version_check and app._available_update:
         print(
             f"\nUpdate available: {__version__} → {app._available_update}\n"
-            f"Run: uv tool upgrade fast-resume"
+            f"{update_instruction()}"
         )
 
     return app.get_resume_command(), app.get_resume_directory()

--- a/src/fast_resume/tui/app.py
+++ b/src/fast_resume/tui/app.py
@@ -19,6 +19,7 @@ from .. import __version__
 from ..adapters.base import ParseError, Session
 from ..config import LOG_FILE
 from ..search import SessionSearch
+from ..update import update_instruction
 from .filter_bar import FILTER_KEYS, FilterBar
 from .modal import YoloModeModal
 from .preview import SessionPreview
@@ -317,7 +318,7 @@ class FastResumeApp(App):
                 self._available_update = latest
                 self.call_from_thread(
                     self.notify,
-                    f"{__version__} → {latest}\nRun [bold]uv tool upgrade fast-resume[/bold] to update",
+                    f"{__version__} → {latest}\n{update_instruction(markup=True)}",
                     title="Update available",
                     timeout=5,
                 )

--- a/src/fast_resume/update.py
+++ b/src/fast_resume/update.py
@@ -1,0 +1,90 @@
+"""Helpers for update notifications."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+PACKAGE_NAME = "fast-resume"
+
+
+def _path_variants(path: Path) -> list[Path]:
+    """Return the raw path and its symlink-resolved form when available."""
+    paths = [path]
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return paths
+    if resolved != path:
+        paths.append(resolved)
+    return paths
+
+
+def executable_paths() -> list[Path]:
+    """Return candidate paths that can reveal how fast-resume was installed."""
+    candidates: list[Path] = []
+
+    for value in (sys.argv[0], sys.executable):
+        if value:
+            candidates.extend(_path_variants(Path(value).expanduser()))
+
+    for executable in ("fr", "fast-resume"):
+        path = shutil.which(executable)
+        if path:
+            candidates.extend(_path_variants(Path(path).expanduser()))
+
+    return candidates
+
+
+def _has_ordered_parts(parts: tuple[str, ...], expected: tuple[str, ...]) -> bool:
+    return any(parts[i : i + len(expected)] == expected for i in range(len(parts)))
+
+
+def detect_install_source(paths: Iterable[Path] | None = None) -> str | None:
+    """Best-effort install source detection from executable path shapes."""
+    candidates = list(paths) if paths is not None else executable_paths()
+
+    for path in candidates:
+        parts = path.parts
+        if _has_ordered_parts(parts, ("Cellar", PACKAGE_NAME)) or _has_ordered_parts(
+            parts, ("opt", PACKAGE_NAME)
+        ):
+            return "homebrew"
+
+    for path in candidates:
+        parts = path.parts
+        if _has_ordered_parts(parts, ("uv", "tools", PACKAGE_NAME)):
+            return "uv"
+
+    for path in candidates:
+        parts = path.parts
+        if _has_ordered_parts(parts, ("pipx", "venvs", PACKAGE_NAME)):
+            return "pipx"
+
+    return None
+
+
+def update_command(paths: Iterable[Path] | None = None) -> str | None:
+    """Return the package-manager command for updating fast-resume."""
+    source = detect_install_source(paths)
+    if source == "homebrew":
+        return f"brew upgrade {PACKAGE_NAME}"
+    if source == "uv":
+        return f"uv tool upgrade {PACKAGE_NAME}"
+    if source == "pipx":
+        return f"pipx upgrade {PACKAGE_NAME}"
+    return None
+
+
+def update_instruction(
+    paths: Iterable[Path] | None = None, *, markup: bool = False
+) -> str:
+    """Return a user-facing update instruction."""
+    command = update_command(paths)
+    if command is None:
+        return "Update with the package manager used to install fast-resume."
+    if markup:
+        return f"Run [bold]{command}[/bold] to update"
+    return f"Run: {command}"

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,59 @@
+"""Tests for update notification helpers."""
+
+from pathlib import Path
+
+from fast_resume.update import detect_install_source, update_command, update_instruction
+
+
+def test_detects_homebrew_from_cellar_path():
+    paths = [Path("/opt/homebrew/Cellar/fast-resume/1.17.3/bin/fr")]
+
+    assert detect_install_source(paths) == "homebrew"
+    assert update_command(paths) == "brew upgrade fast-resume"
+
+
+def test_detects_homebrew_from_opt_path():
+    paths = [Path("/opt/homebrew/opt/fast-resume/bin/fr")]
+
+    assert detect_install_source(paths) == "homebrew"
+
+
+def test_detects_uv_tool_install_path():
+    paths = [Path("/Users/test/.local/share/uv/tools/fast-resume/bin/fr")]
+
+    assert detect_install_source(paths) == "uv"
+    assert update_command(paths) == "uv tool upgrade fast-resume"
+
+
+def test_detects_pipx_install_path():
+    paths = [Path("/Users/test/.local/pipx/venvs/fast-resume/bin/fr")]
+
+    assert detect_install_source(paths) == "pipx"
+    assert update_command(paths) == "pipx upgrade fast-resume"
+
+
+def test_homebrew_wins_when_invoked_directly_with_uv_first_on_path():
+    paths = [
+        Path("/Users/test/.local/share/uv/tools/fast-resume/bin/fr"),
+        Path("/opt/homebrew/Cellar/fast-resume/1.17.3/bin/fr"),
+    ]
+
+    assert detect_install_source(paths) == "homebrew"
+
+
+def test_unknown_install_source_uses_neutral_instruction():
+    paths = [Path("/tmp/fast-resume/fr")]
+
+    assert update_command(paths) is None
+    assert (
+        update_instruction(paths)
+        == "Update with the package manager used to install fast-resume."
+    )
+
+
+def test_update_instruction_can_use_rich_markup():
+    paths = [Path("/opt/homebrew/Cellar/fast-resume/1.17.3/bin/fr")]
+
+    assert update_instruction(paths, markup=True) == (
+        "Run [bold]brew upgrade fast-resume[/bold] to update"
+    )


### PR DESCRIPTION
## Context

Update notifications always told users to run `uv tool upgrade fast-resume`, even when the executable came from another installer such as Homebrew.

## Changes

- **Update instructions:** stop hardcoding the uv upgrade command; now derive the instruction from the current executable path so Homebrew, uv, and pipx installs get matching commands.
- **Fallback behavior:** show a neutral package-manager update instruction when the install source cannot be detected, instead of recommending the wrong installer.
- **Coverage:** add focused tests for Homebrew, uv, pipx, precedence, and unknown-source formatting.

## Compatibility note

No CLI flags or persisted data change. The version check still compares against PyPI; only the displayed update instruction changes.

<details>
<summary>Verification</summary>

```bash
uv run pytest tests/test_update.py -q
uv run pytest tests/test_tui.py::TestFastResumeAppBasic::test_no_version_check_skips_update_check tests/test_tui.py::TestFastResumeAppBasic::test_version_check_runs_by_default -q
```

</details>
