### PR TITLE
feat: add F2 as a preview-toggle key for non-US keyboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Options:
 
 | Key       | Action                                |
 | --------- | ------------------------------------- |
-| `Ctrl+\`` | Toggle preview pane (or `F2`)          |
+| `F2`      | Toggle preview pane (or `Ctrl+\``)     |
 | `+` / `-` | Resize preview pane                   |
 | `Tab`     | Accept autocomplete suggestion        |
 | `c`       | Copy full resume command to clipboard |

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Options:
 
 | Key       | Action                                |
 | --------- | ------------------------------------- |
-| `Ctrl+\`` | Toggle preview pane                   |
+| `Ctrl+\`` | Toggle preview pane (or `F2`)          |
 | `+` / `-` | Resize preview pane                   |
 | `Tab`     | Accept autocomplete suggestion        |
 | `c`       | Copy full resume command to clipboard |

--- a/src/fast_resume/tui/app.py
+++ b/src/fast_resume/tui/app.py
@@ -50,7 +50,7 @@ class FastResumeApp(App):
         Binding("ctrl+grave_accent", "toggle_preview", "Preview", priority=True),
         # F2 is a layout-independent alternative; Ctrl+` is hard to reach on many
         # non-US keyboards (e.g. the backtick is a dead key on Nordic layouts).
-        Binding("f2", "toggle_preview", "Preview", show=False, priority=True),
+        Binding("f2", "toggle_preview", "Preview", priority=True),
         Binding("tab", "accept_suggestion", "Accept", show=False, priority=True),
         Binding("j", "cursor_down", "Down", show=False),
         Binding("k", "cursor_up", "Up", show=False),

--- a/src/fast_resume/tui/app.py
+++ b/src/fast_resume/tui/app.py
@@ -47,10 +47,14 @@ class FastResumeApp(App):
         Binding("/", "focus_search", "Search", priority=True),
         Binding("enter", "resume_session", "Resume"),
         Binding("c", "copy_path", "Copy resume command", priority=True),
-        Binding("ctrl+grave_accent", "toggle_preview", "Preview", priority=True),
-        # F2 is a layout-independent alternative; Ctrl+` is hard to reach on many
-        # non-US keyboards (e.g. the backtick is a dead key on Nordic layouts).
-        Binding("f2", "toggle_preview_alt", "Preview", priority=True),
+        # F2 is the primary, layout-independent toggle shown in the footer. Ctrl+`
+        # still works but is hidden: the backtick is hard to reach on many non-US
+        # keyboards (e.g. a dead key on Nordic layouts). Textual's footer groups by
+        # action and skips show=False bindings, so only F2 appears.
+        Binding("f2", "toggle_preview", "Preview", priority=True),
+        Binding(
+            "ctrl+grave_accent", "toggle_preview", "Preview", show=False, priority=True
+        ),
         Binding("tab", "accept_suggestion", "Accept", show=False, priority=True),
         Binding("j", "cursor_down", "Down", show=False),
         Binding("k", "cursor_up", "Up", show=False),
@@ -527,12 +531,6 @@ class FastResumeApp(App):
             preview_container.remove_class("hidden")
         else:
             preview_container.add_class("hidden")
-
-    # Distinct action so the footer shows F2 as its own entry: Textual's Footer
-    # groups bindings by action and renders only one key per action.
-    def action_toggle_preview_alt(self) -> None:
-        """Alias for the preview toggle, bound to F2 (see action_toggle_preview)."""
-        self.action_toggle_preview()
 
     def action_cursor_down(self) -> None:
         """Move cursor down in results."""

--- a/src/fast_resume/tui/app.py
+++ b/src/fast_resume/tui/app.py
@@ -50,7 +50,7 @@ class FastResumeApp(App):
         Binding("ctrl+grave_accent", "toggle_preview", "Preview", priority=True),
         # F2 is a layout-independent alternative; Ctrl+` is hard to reach on many
         # non-US keyboards (e.g. the backtick is a dead key on Nordic layouts).
-        Binding("f2", "toggle_preview", "Preview", priority=True),
+        Binding("f2", "toggle_preview_alt", "Preview", priority=True),
         Binding("tab", "accept_suggestion", "Accept", show=False, priority=True),
         Binding("j", "cursor_down", "Down", show=False),
         Binding("k", "cursor_up", "Up", show=False),
@@ -527,6 +527,12 @@ class FastResumeApp(App):
             preview_container.remove_class("hidden")
         else:
             preview_container.add_class("hidden")
+
+    # Distinct action so the footer shows F2 as its own entry: Textual's Footer
+    # groups bindings by action and renders only one key per action.
+    def action_toggle_preview_alt(self) -> None:
+        """Alias for the preview toggle, bound to F2 (see action_toggle_preview)."""
+        self.action_toggle_preview()
 
     def action_cursor_down(self) -> None:
         """Move cursor down in results."""

--- a/src/fast_resume/tui/app.py
+++ b/src/fast_resume/tui/app.py
@@ -48,6 +48,9 @@ class FastResumeApp(App):
         Binding("enter", "resume_session", "Resume"),
         Binding("c", "copy_path", "Copy resume command", priority=True),
         Binding("ctrl+grave_accent", "toggle_preview", "Preview", priority=True),
+        # F2 is a layout-independent alternative; Ctrl+` is hard to reach on many
+        # non-US keyboards (e.g. the backtick is a dead key on Nordic layouts).
+        Binding("f2", "toggle_preview", "Preview", show=False, priority=True),
         Binding("tab", "accept_suggestion", "Accept", show=False, priority=True),
         Binding("j", "cursor_down", "Down", show=False),
         Binding("k", "cursor_up", "Up", show=False),

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -664,6 +664,23 @@ class TestFastResumeAppNavigation:
                 await pilot.press("ctrl+grave_accent")
                 assert app.show_preview is True
 
+    @pytest.mark.asyncio
+    async def test_f2_toggles_preview(self, mock_search_engine):
+        """F2 toggles the preview pane (layout-independent alternative to Ctrl+`)."""
+        with patch(
+            "fast_resume.tui.app.SessionSearch", return_value=mock_search_engine
+        ):
+            app = FastResumeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                assert app.show_preview is True
+
+                await pilot.press("f2")
+                assert app.show_preview is False
+
+                await pilot.press("f2")
+                assert app.show_preview is True
+
 
 class TestFastResumeAppSearch:
     """Tests for search functionality."""

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -681,21 +681,20 @@ class TestFastResumeAppNavigation:
                 await pilot.press("f2")
                 assert app.show_preview is True
 
-    def test_f2_uses_distinct_action_so_footer_shows_it(self):
-        """F2 must use a separate action from Ctrl+`.
+    def test_f2_is_the_shown_preview_binding(self):
+        """F2 is the footer-visible preview toggle; Ctrl+` is a hidden alternative.
 
-        Textual's Footer groups bindings by action and renders only one key per
-        action, so both keys sharing 'toggle_preview' would hide F2 from the
-        footer. A distinct (delegating) action gives F2 its own footer entry.
+        Textual's Footer groups bindings by action and skips show=False bindings,
+        so marking Ctrl+` hidden leaves F2 as the single visible 'Preview' entry
+        while both keys still trigger the toggle.
         """
-        actions = {
-            b.key: b.action
+        preview = {
+            b.key: b
             for b in FastResumeApp.BINDINGS
-            if b.key in ("f2", "ctrl+grave_accent")
+            if b.action == "toggle_preview" and b.key in ("f2", "ctrl+grave_accent")
         }
-        assert actions["ctrl+grave_accent"] == "toggle_preview"
-        assert actions["f2"] == "toggle_preview_alt"
-        assert actions["f2"] != actions["ctrl+grave_accent"]
+        assert preview["f2"].show is True
+        assert preview["ctrl+grave_accent"].show is False
 
 
 class TestFastResumeAppSearch:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -681,6 +681,22 @@ class TestFastResumeAppNavigation:
                 await pilot.press("f2")
                 assert app.show_preview is True
 
+    def test_f2_uses_distinct_action_so_footer_shows_it(self):
+        """F2 must use a separate action from Ctrl+`.
+
+        Textual's Footer groups bindings by action and renders only one key per
+        action, so both keys sharing 'toggle_preview' would hide F2 from the
+        footer. A distinct (delegating) action gives F2 its own footer entry.
+        """
+        actions = {
+            b.key: b.action
+            for b in FastResumeApp.BINDINGS
+            if b.key in ("f2", "ctrl+grave_accent")
+        }
+        assert actions["ctrl+grave_accent"] == "toggle_preview"
+        assert actions["f2"] == "toggle_preview_alt"
+        assert actions["f2"] != actions["ctrl+grave_accent"]
+
 
 class TestFastResumeAppSearch:
     """Tests for search functionality."""


### PR DESCRIPTION
## What

Makes **F2** the preview-toggle key shown in the footer, with **Ctrl+`** kept as a hidden (still functional) alternative.

## Why

`Ctrl+`` `` is hard to reach on many non-US keyboard layouts. On Nordic layouts (Danish/Norwegian/Swedish) the backtick is a **dead key** reached via `Shift`, and `Ctrl` + a dead key rarely registers as a plain backtick in terminals — effectively unusable. German/French and others place it behind `AltGr`/dead keys too. `F2` is layout-independent and works everywhere.

## Change

```python
Binding("f2", "toggle_preview", "Preview", priority=True),
Binding("ctrl+grave_accent", "toggle_preview", "Preview", show=False, priority=True),
```

Both keys trigger the same action. Textual's `Footer` groups bindings by action and skips `show=False` ones, so the footer shows a single **F2 Preview** entry; `Ctrl+`` `` still works for anyone used to it. README keybindings table updated accordingly.

## Tests

- `test_f2_toggles_preview` — pressing `f2` flips the preview (pilot).
- `test_f2_is_the_shown_preview_binding` — guards the footer visibility (F2 `show=True`, Ctrl+` `show=False`).

Full suite passes.
