### PR TITLE
feat: use Claude Code's generated session title (aiTitle)

### DIFF
--- a/src/fast_resume/adapters/claude.py
+++ b/src/fast_resume/adapters/claude.py
@@ -50,6 +50,7 @@ class ClaudeAdapter(BaseSessionAdapter):
         """Parse a Claude Code session file."""
         try:
             first_user_message = ""
+            ai_title = ""
             directory = ""
             timestamp = datetime.fromtimestamp(session_file.stat().st_mtime)
             messages: list[str] = []
@@ -67,6 +68,12 @@ class ClaudeAdapter(BaseSessionAdapter):
                         continue
 
                     msg_type = data.get("type", "")
+
+                    # Claude Code's auto-generated session title (shown in its
+                    # own Resume UI). It gets rewritten as the session evolves,
+                    # so keep the latest non-empty one.
+                    if msg_type == "ai-title" and data.get("aiTitle"):
+                        ai_title = data["aiTitle"]
 
                     # Get directory from user message
                     if msg_type == "user" and not directory:
@@ -139,9 +146,12 @@ class ClaudeAdapter(BaseSessionAdapter):
             if not first_user_message:
                 return None
 
-            # Prefer Claude's session-list title when available. This is where
-            # /rename stores the display name; older sessions may not have one.
-            title_source = self._get_index_title(session_file) or first_user_message
+            # Prefer Claude's own list title when available: a /rename display
+            # name (sessions-index.json), then Claude's auto-generated aiTitle
+            # (the title shown in its Resume UI), then the first user message.
+            title_source = (
+                self._get_index_title(session_file) or ai_title or first_user_message
+            )
             title = truncate_title(title_source)
 
             # Skip sessions with no actual conversation content

--- a/tests/test_claude_adapter.py
+++ b/tests/test_claude_adapter.py
@@ -151,6 +151,117 @@ class TestClaudeAdapter:
         assert session.title == "Renamed Claude thread"
         assert "Original first prompt" in session.content
 
+    def test_parse_session_prefers_ai_title(self, adapter, temp_dir):
+        """Test that Claude's auto-generated ai-title is used as the title."""
+        project_dir = temp_dir / "projects" / "project-abc123"
+        project_dir.mkdir(parents=True)
+        session_file = project_dir / "session-ai-title.jsonl"
+
+        data = [
+            {
+                "type": "user",
+                "cwd": "/home/user/project",
+                "message": {"content": "Help me fix this bug in the login system"},
+            },
+            {
+                "type": "ai-title",
+                "aiTitle": "Fix login token validation",
+                "sessionId": "session-ai-title",
+            },
+            {
+                "type": "assistant",
+                "message": {"content": "On it."},
+            },
+        ]
+
+        with open(session_file, "w") as f:
+            for entry in data:
+                f.write(json.dumps(entry) + "\n")
+
+        session = adapter._parse_session_file(session_file)
+
+        assert session is not None
+        assert session.title == "Fix login token validation"
+        assert "Help me fix this bug" in session.content
+
+    def test_parse_session_uses_latest_ai_title(self, adapter, temp_dir):
+        """Test that the most recent ai-title wins when it is rewritten."""
+        project_dir = temp_dir / "projects" / "project-abc123"
+        project_dir.mkdir(parents=True)
+        session_file = project_dir / "session-ai-latest.jsonl"
+
+        data = [
+            {
+                "type": "user",
+                "cwd": "/home/user/project",
+                "message": {"content": "Start working on something"},
+            },
+            {
+                "type": "ai-title",
+                "aiTitle": "First guess at the topic",
+                "sessionId": "session-ai-latest",
+            },
+            {
+                "type": "ai-title",
+                "aiTitle": "What the session became",
+                "sessionId": "session-ai-latest",
+            },
+        ]
+
+        with open(session_file, "w") as f:
+            for entry in data:
+                f.write(json.dumps(entry) + "\n")
+
+        session = adapter._parse_session_file(session_file)
+
+        assert session is not None
+        assert session.title == "What the session became"
+
+    def test_parse_session_rename_overrides_ai_title(self, temp_dir):
+        """Test that a /rename title takes precedence over the auto ai-title."""
+        project_dir = temp_dir / "projects" / "project-abc123"
+        project_dir.mkdir(parents=True)
+        session_file = project_dir / "session-rename-ai.jsonl"
+
+        data = [
+            {
+                "type": "user",
+                "cwd": "/home/user/project",
+                "message": {"content": "Original first prompt for this session"},
+            },
+            {
+                "type": "ai-title",
+                "aiTitle": "Auto generated title",
+                "sessionId": "session-rename-ai",
+            },
+        ]
+
+        with open(session_file, "w") as f:
+            for entry in data:
+                f.write(json.dumps(entry) + "\n")
+
+        with open(project_dir / "sessions-index.json", "w") as f:
+            json.dump(
+                {
+                    "version": 1,
+                    "entries": [
+                        {
+                            "sessionId": "session-rename-ai",
+                            "summary": "Renamed Claude thread",
+                            "modified": "2026-06-03T16:11:02.882Z",
+                            "fileMtime": 1780503062882,
+                        }
+                    ],
+                },
+                f,
+            )
+
+        adapter = ClaudeAdapter(sessions_dir=temp_dir / "projects")
+        session = adapter._parse_session_file(session_file)
+
+        assert session is not None
+        assert session.title == "Renamed Claude thread"
+
     def test_parse_session_with_list_content(self, adapter, temp_dir):
         """Test parsing session with list-style content (multi-part messages)."""
         project_dir = temp_dir / "projects" / "project-abc123"


### PR DESCRIPTION
Claude Code auto-generates a title for each session and writes it into the transcript as an `ai-title` record. It's the title Claude's own resume picker shows, but this adapter ignored it and titled sessions from the first user message.

That falls apart for sessions started from a slash command or skill: the first "user message" is the injected command/skill preamble, so they all show up as something like `Base directory for this skill: /home/...` and you can't tell them apart in the list.

This reads the `ai-title` record when it's present. The order becomes a `/rename` title (the sessions-index.json support from #51) first, then the auto `aiTitle`, then the first user message, which lines up with what Claude Code itself shows. A session can rewrite its title as it goes, so the latest record wins.

Sessions without an `ai-title` record behave exactly as before, and the record is read in the existing parse loop so there's no extra I/O.

Tests added: auto title used, `/rename` still winning over it, and the latest title winning.

I put the auto title below an explicit `/rename` on the assumption a manual rename should win, but that's easy to swap if you'd rather `aiTitle` take priority.
