### PR TITLE
ci: speed up Rust builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,21 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      cargo-patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions-non-major-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -62,6 +62,9 @@ jobs:
   python-wheel:
     name: Python wheel (${{ matrix.platform.name }})
     runs-on: ${{ matrix.platform.runner }}
+    env:
+      SCCACHE_GHA_CACHE_FROM: ${{ matrix.platform.target }}
+      SCCACHE_GHA_CACHE_TO: ${{ matrix.platform.target }}
     strategy:
       fail-fast: false
       matrix:
@@ -251,6 +254,9 @@ jobs:
     needs: [release]
     if: needs.release.outputs.new_release_version != ''
     runs-on: ${{ matrix.platform.runner }}
+    env:
+      SCCACHE_GHA_CACHE_FROM: ${{ matrix.platform.target }}
+      SCCACHE_GHA_CACHE_TO: ${{ matrix.platform.target }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,6 +11,10 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   commitlint:
     name: Commit Lint
@@ -38,6 +42,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+      - name: Cache Cargo dependencies and build output
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ runner.arch }}-debug-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-${{ runner.arch }}-debug-
       - name: Check formatting
         run: cargo fmt --check
       - name: Run tests
@@ -80,6 +94,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: v1.14.1
+          sccache: true
           target: ${{ matrix.platform.target }}
           manylinux: ${{ matrix.platform.manylinux }}
           args: --release --locked --out dist --compatibility pypi
@@ -89,6 +104,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: v1.14.1
+          sccache: true
           target: ${{ matrix.platform.target }}
           args: --release --locked --out dist --compatibility pypi
 
@@ -97,6 +113,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: v1.14.1
+          sccache: true
           target: ${{ matrix.platform.target }}
           args: --release --locked --out dist --compatibility pypi
 
@@ -191,6 +208,17 @@ jobs:
           ref: v${{ needs.release.outputs.new_release_version }}
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Cargo dependencies and release build output
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ runner.arch }}-release-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-${{ runner.arch }}-release-
+
       - name: Build binary
         run: cargo build --release --locked
 
@@ -264,6 +292,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: v1.14.1
+          sccache: true
           target: ${{ matrix.platform.target }}
           manylinux: ${{ matrix.platform.manylinux }}
           args: --release --locked --out dist --compatibility pypi
@@ -273,6 +302,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: v1.14.1
+          sccache: true
           target: ${{ matrix.platform.target }}
           args: --release --locked --out dist --compatibility pypi
 
@@ -281,6 +311,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: v1.14.1
+          sccache: true
           target: ${{ matrix.platform.target }}
           args: --release --locked --out dist --compatibility pypi
 


### PR DESCRIPTION
## Summary

- cache Cargo registry, git dependencies, and build output with GitHub-owned actions/cache
- enable the existing Maturin action sccache integration for wheel builds
- cancel superseded pull request workflow runs
- group low-risk Dependabot patch updates to reduce duplicate matrix runs

## Why

The v2.0.0 workflow compiled Rust across multiple validation and release matrices. These changes reduce repeated dependency downloads and compilation while leaving release orchestration unchanged. The first run will populate cold caches; later runs provide the useful timing comparison.

Riskier Cargo minor updates and major GitHub Actions updates remain in separate Dependabot pull requests.

## Validation

- cargo fmt --all --check
- cargo check --all-targets --locked
- TZ=UTC cargo test --locked
- parsed both YAML files with the system YAML parser
- git diff --check