### PR TITLE
Speed up initial indexing

### DIFF
--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -54,7 +54,7 @@ impl CodexAdapter {
         let mut yolo = false;
 
         for line in BufReader::new(file).lines().map_while(Result::ok) {
-            if line.trim().is_empty() {
+            if !codex_line_may_affect_index(&line) {
                 continue;
             }
             let Ok(data) = serde_json::from_str::<Value>(&line) else {
@@ -227,6 +227,20 @@ impl CodexAdapter {
     }
 }
 
+fn codex_line_may_affect_index(line: &str) -> bool {
+    if line.trim().is_empty() {
+        return false;
+    }
+    if line.contains("session_meta") || line.contains("turn_context") {
+        return true;
+    }
+    if line.contains("response_item") {
+        return line.contains("role") && (line.contains("user") || line.contains("assistant"));
+    }
+    line.contains("event_msg")
+        && (line.contains("user_message") || line.contains("agent_reasoning"))
+}
+
 impl Adapter for CodexAdapter {
     fn name(&self) -> &'static str {
         "codex"
@@ -364,6 +378,30 @@ mod tests {
                 .join("\n"),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn prefilter_keeps_only_rows_that_can_affect_index() {
+        assert!(codex_line_may_affect_index(
+            r#"{"type":"session_meta","payload":{"id":"abc","cwd":"/work"}}"#
+        ));
+        assert!(codex_line_may_affect_index(
+            r#"{"type":"turn_context","payload":{"approval_policy":"never"}}"#
+        ));
+        assert!(codex_line_may_affect_index(
+            r#"{"type":"response_item","payload":{"role":"assistant","content":[{"text":"answer"}]}}"#
+        ));
+        assert!(codex_line_may_affect_index(
+            r#"{"type":"event_msg","payload":{"type":"user_message","message":"prompt"}}"#
+        ));
+
+        assert!(!codex_line_may_affect_index(""));
+        assert!(!codex_line_may_affect_index(
+            r#"{"type":"event_msg","payload":{"type":"token_count"}}"#
+        ));
+        assert!(!codex_line_may_affect_index(
+            r#"{"type":"response_item","payload":{"type":"function_call_output","output":"large tool output"}}"#
+        ));
     }
 
     #[test]

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -53,6 +53,13 @@ where
     F: FnMut(RefreshSummary),
 {
     let known = index.known_sessions()?;
+    if known.is_empty() {
+        let sessions = scan_all_sessions();
+        let summary = index.rebuild(sessions)?;
+        on_progress(summary.clone());
+        return Ok(summary);
+    }
+
     let (tx, rx) = mpsc::channel();
     let trace_refresh = env::var_os("FAST_RESUME_TRACE_REFRESH").is_some();
     for adapter in all_adapters() {


### PR DESCRIPTION
## Summary

Speed up first-time indexing for large local histories, especially Codex logs that contain many non-searchable tool and telemetry rows.

Before this change, the TUI's empty-index startup used the incremental refresh path. That path is intentionally conservative for existing indexes, but it also performs JSONL health checks before parsing. On a fresh index there are no old documents to preserve, so this now uses the full scan/rebuild path directly.

Codex parsing also now does a cheap raw-line prefilter before `serde_json` parsing. It only parses rows that can affect the indexed session projection: session metadata, yolo context, user/assistant response items, user prompts, and assistant reasoning. Large tool-call/output/token-count rows are skipped before JSON parsing.

## Notes

- Incremental refresh behavior for existing indexes stays conservative; malformed/partial JSONL protection is still used when there are known sessions.
- The Codex prefilter is intentionally permissive: false positives are okay because they only fall back to the existing JSON parser, while irrelevant common rows avoid that cost.

<details>
<summary>Verification</summary>

```bash
cargo test
```

Local benchmark on a history with ~4.4k sessions and ~6.7 GB of Codex JSONL:

```text
baseline release empty-index refresh: ~14.2s
optimized release empty-index refresh: ~5.5-6.1s

baseline debug empty-index refresh: ~125s
optimized debug empty-index refresh: ~121s
```

The release improvement comes from skipping the incremental JSONL health pass on an empty index and avoiding JSON parsing for irrelevant Codex rows. Debug remains slow because unoptimized Tantivy indexing still dominates the final rebuild/commit.

</details>
