### PR TITLE
feat(tui): hide agents without sessions

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -351,9 +351,13 @@ mod tests {
     }
 
     fn session_in(id: &str, directory: &str) -> Session {
+        session_for_agent(id, "codex", directory)
+    }
+
+    fn session_for_agent(id: &str, agent: &str, directory: &str) -> Session {
         Session::new(
             id,
-            "codex",
+            agent,
             format!("Session {id}"),
             directory,
             Local::now(),
@@ -504,8 +508,17 @@ mod tests {
     }
 
     #[test]
-    fn tab_cycles_filter_into_query_when_there_is_no_suggestion() {
-        let mut state = test_state(Vec::new());
+    fn filter_tabs_and_cycle_include_only_agents_with_sessions() {
+        let mut state = test_state(vec![
+            session_for_agent("codex-1", "codex", "/tmp/codex"),
+            session_for_agent("claude-1", "claude", "/tmp/claude"),
+            session_for_agent("codex-2", "codex", "/tmp/codex"),
+        ]);
+
+        assert_eq!(
+            state.agent_filters_with_sessions(),
+            vec![("claude", 1), ("codex", 2)]
+        );
 
         handle_key(&mut state, key(KeyCode::Tab, KeyModifiers::NONE)).unwrap();
 
@@ -518,11 +531,23 @@ mod tests {
     }
 
     #[test]
-    fn deleting_cycled_filter_keyword_clears_filter() {
+    fn filter_cycle_stays_on_all_when_no_agent_has_sessions() {
         let mut state = test_state(Vec::new());
 
         handle_key(&mut state, key(KeyCode::Tab, KeyModifiers::NONE)).unwrap();
-        for _ in 0.."agent:claude".chars().count() {
+
+        assert!(state.agent_filters_with_sessions().is_empty());
+        assert!(state.query.is_empty());
+        assert!(state.all_agent_filter_active());
+    }
+
+    #[test]
+    fn deleting_cycled_filter_keyword_clears_filter() {
+        let mut state = test_state(vec![session("codex-1")]);
+
+        handle_key(&mut state, key(KeyCode::Tab, KeyModifiers::NONE)).unwrap();
+        let query_len = state.query.chars().count();
+        for _ in 0..query_len {
             handle_key(&mut state, key(KeyCode::Backspace, KeyModifiers::NONE)).unwrap();
         }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -6,7 +6,7 @@ use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Wrap};
 use ratatui_image::{Image as TuiImage, protocol::Protocol};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-use crate::config::{AGENT_ORDER, AGENTS, VERSION};
+use crate::config::{AGENTS, VERSION};
 use crate::model::Session;
 
 use super::layout::{self, MainLayout};
@@ -168,13 +168,14 @@ fn draw_filters(frame: &mut Frame, area: Rect, state: &AppState) {
     }
 
     let active_agents = state.active_agent_filters();
-    let tabs: Vec<_> = AGENT_ORDER
+    let available_agents = state.agent_filters_with_sessions();
+    let tabs: Vec<_> = available_agents
         .iter()
-        .map(|agent| {
+        .map(|(agent, count)| {
             let config = AGENTS.get(agent).expect("known agent");
             AgentFilterTab {
                 label: config.badge,
-                count: state.engine.count_for_agent(Some(agent)),
+                count: *count,
                 has_icon: state
                     .images
                     .as_ref()
@@ -197,7 +198,7 @@ fn draw_filters(frame: &mut Frame, area: Rect, state: &AppState) {
             None,
         );
     }
-    for (index, agent) in AGENT_ORDER.iter().enumerate() {
+    for (index, (agent, _)) in available_agents.iter().enumerate() {
         if !filter_layout.visible_agents.contains(&index) {
             continue;
         }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -275,6 +275,16 @@ impl AppState {
         self.agent_filter.is_none() && !query_has_agent_filter(&self.query)
     }
 
+    pub(super) fn agent_filters_with_sessions(&self) -> Vec<(&'static str, usize)> {
+        AGENT_ORDER
+            .iter()
+            .filter_map(|agent| {
+                let count = self.engine.count_for_agent(Some(agent));
+                (count > 0).then_some((*agent, count))
+            })
+            .collect()
+    }
+
     pub(super) fn count_agent_filter(&self) -> Option<String> {
         if let Some(agent) = single_query_agent_filter(&self.query) {
             return Some(agent);
@@ -305,13 +315,18 @@ impl AppState {
     }
 
     pub(super) fn cycle_agent(&mut self, reverse: bool) {
+        let available = self.agent_filters_with_sessions();
         let active = self.active_agent_filter();
         let current = active
             .as_deref()
-            .and_then(|agent| AGENT_ORDER.iter().position(|candidate| *candidate == agent))
+            .and_then(|agent| {
+                available
+                    .iter()
+                    .position(|(candidate, _)| *candidate == agent)
+            })
             .map(|idx| idx + 1)
             .unwrap_or(0);
-        let len = AGENT_ORDER.len() + 1;
+        let len = available.len() + 1;
         let next = if reverse {
             (current + len - 1) % len
         } else {
@@ -320,7 +335,7 @@ impl AppState {
         let next_agent = if next == 0 {
             None
         } else {
-            Some(AGENT_ORDER[next - 1].to_string())
+            Some(available[next - 1].0.to_string())
         };
         self.query = update_agent_in_query(&self.query, next_agent.as_deref());
         self.cursor = self.query.chars().count();


### PR DESCRIPTION
## Summary

- hide agent filter tabs when the index contains no sessions for that agent
- make Tab and Shift-Tab cycle through only the filters currently backed by sessions
- keep typed `agent:<name>` filters and autocomplete available for every supported agent
- cover mixed-agent and empty-index behavior

```text
indexed session counts ──► nonempty agents ──► filter tabs + keyboard cycle
all supported agents ───────────────────────► typed query autocomplete
```
