### PR TITLE
feat(tui): add keyboard help and Emacs editing

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -166,14 +166,27 @@ Options:
 
 ## Keybindings
 
-### Search and navigation
+Press `F1` in the TUI to show all keyboard shortcuts.
+
+### Search input
+
+| Key | Action |
+| --- | --- |
+| `←` / `→` or `Ctrl+B` / `Ctrl+F` | Move the cursor |
+| `Home` / `End` or `Ctrl+A` / `Ctrl+E` | Move to the start or end |
+| `Backspace` | Delete the previous character |
+| `Delete` / `Ctrl+D` | Delete the next character |
+| `Ctrl+W` | Delete the previous word |
+| `Ctrl+U` | Delete to the start |
+| `Tab` / `Shift+Tab` | Accept a suggestion or cycle the agent filter |
+
+### Results navigation
 
 | Key | Action |
 | --- | --- |
 | `↑` / `↓` | Move selection |
 | `Ctrl+J` / `Ctrl+K` | Move selection |
 | `Page Up` / `Page Down` | Move by 10 rows |
-| `Tab` / `Shift+Tab` | Accept a suggestion or cycle the agent filter |
 | `Enter` | Resume the selected session |
 
 ### Preview and actions
@@ -184,6 +197,7 @@ Options:
 | `Alt`+`+` / `Alt`+`-` | Scroll the preview pane |
 | Mouse wheel | Scroll the list or preview under the pointer |
 | `Ctrl+Y` | Copy the complete resume command |
+| `F1` | Show or close keyboard help |
 | `Esc` / `Ctrl+C` | Quit |
 
 ### Yolo confirmation

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -526,6 +526,59 @@ mod tests {
     }
 
     #[test]
+    fn f1_opens_help_and_suspends_search_input() {
+        let mut state = test_state(Vec::new());
+
+        handle_key(&mut state, key(KeyCode::F(1), KeyModifiers::NONE)).unwrap();
+        assert!(state.show_help);
+
+        handle_key(&mut state, key(KeyCode::Char('z'), KeyModifiers::NONE)).unwrap();
+        assert!(state.query.is_empty());
+
+        handle_key(&mut state, key(KeyCode::F(1), KeyModifiers::NONE)).unwrap();
+        assert!(!state.show_help);
+    }
+
+    #[test]
+    fn emacs_keys_move_the_search_cursor() {
+        let mut state = test_state(Vec::new());
+        type_query(&mut state, "alpha βeta");
+        let end = state.query.chars().count();
+
+        handle_key(&mut state, key(KeyCode::Char('a'), KeyModifiers::CONTROL)).unwrap();
+        assert_eq!(state.cursor, 0);
+
+        handle_key(&mut state, key(KeyCode::Char('f'), KeyModifiers::CONTROL)).unwrap();
+        assert_eq!(state.cursor, 1);
+
+        handle_key(&mut state, key(KeyCode::Char('b'), KeyModifiers::CONTROL)).unwrap();
+        assert_eq!(state.cursor, 0);
+
+        handle_key(&mut state, key(KeyCode::Char('e'), KeyModifiers::CONTROL)).unwrap();
+        assert_eq!(state.cursor, end);
+    }
+
+    #[test]
+    fn emacs_keys_delete_search_text() {
+        let mut state = test_state(Vec::new());
+        type_query(&mut state, "aβc");
+        state.cursor = 1;
+
+        handle_key(&mut state, key(KeyCode::Char('d'), KeyModifiers::CONTROL)).unwrap();
+        assert_eq!(state.query, "ac");
+        assert_eq!(state.cursor, 1);
+
+        state.cursor = state.query.chars().count();
+        type_query(&mut state, " beta  ");
+        handle_key(&mut state, key(KeyCode::Char('w'), KeyModifiers::CONTROL)).unwrap();
+        assert_eq!(state.query, "ac ");
+
+        handle_key(&mut state, key(KeyCode::Char('u'), KeyModifiers::CONTROL)).unwrap();
+        assert!(state.query.is_empty());
+        assert_eq!(state.cursor, 0);
+    }
+
+    #[test]
     fn alt_plus_and_minus_scroll_preview() {
         let mut state = test_state(Vec::new());
         state.preview_scroll = 3;

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -9,11 +9,34 @@ use super::state::{AppState, PENDING_SEARCH_STATUS, PendingAction, YoloModal};
 use super::text::{shell_join, shell_quote};
 
 pub(super) fn handle_key(state: &mut AppState, key: KeyEvent) -> Result<Option<TuiExit>> {
+    if state.show_help {
+        if matches!(key.code, KeyCode::F(1) | KeyCode::Esc) {
+            state.show_help = false;
+        }
+        return Ok(None);
+    }
+    if key.code == KeyCode::F(1) {
+        state.show_help = true;
+        return Ok(None);
+    }
     if state.modal.is_some() {
         return handle_modal_key(state, key);
     }
 
     match (key.code, key.modifiers) {
+        (KeyCode::Char('a'), KeyModifiers::CONTROL) => state.cursor = 0,
+        (KeyCode::Char('b'), KeyModifiers::CONTROL) => {
+            state.cursor = state.cursor.saturating_sub(1);
+        }
+        (KeyCode::Char('d'), KeyModifiers::CONTROL) => state.delete(),
+        (KeyCode::Char('e'), KeyModifiers::CONTROL) => {
+            state.cursor = state.query.chars().count();
+        }
+        (KeyCode::Char('f'), KeyModifiers::CONTROL) => {
+            state.cursor = (state.cursor + 1).min(state.query.chars().count());
+        }
+        (KeyCode::Char('u'), KeyModifiers::CONTROL) => state.delete_to_start(),
+        (KeyCode::Char('w'), KeyModifiers::CONTROL) => state.delete_previous_word(),
         (KeyCode::Char('c'), KeyModifiers::CONTROL) => return Ok(Some(TuiExit::Quit)),
         (KeyCode::Char('y'), KeyModifiers::CONTROL) => {
             if let Some(exit) = begin_action(state, PendingAction::Copy)? {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -27,7 +27,9 @@ pub(super) fn draw(frame: &mut Frame, state: &AppState) {
     draw_main(frame, layout.main, state);
     draw_footer(frame, layout.footer, state);
 
-    if let Some(modal) = &state.modal {
+    if state.show_help {
+        draw_help_modal(frame, area, &state.theme);
+    } else if let Some(modal) = &state.modal {
         draw_yolo_modal(frame, area, modal, &state.theme);
     }
 }
@@ -804,6 +806,8 @@ fn shortcut_footer(theme: &Theme) -> Line<'static> {
         Span::raw(" agent  "),
         Span::styled(" Ctrl+P ", Style::new().fg(theme.key_fg).bg(theme.key_bg)),
         Span::raw(" preview  "),
+        Span::styled(" F1 ", Style::new().fg(theme.key_fg).bg(theme.key_bg)),
+        Span::raw(" help  "),
         Span::styled(" Esc ", Style::new().fg(theme.key_fg).bg(theme.key_bg)),
         Span::raw(" quit"),
     ])
@@ -832,6 +836,46 @@ fn footer_line(status: &str, width: u16, theme: &Theme) -> Line<'static> {
     ];
     spans.extend(shortcuts.spans);
     Line::from(spans)
+}
+
+fn draw_help_modal(frame: &mut Frame, area: Rect, theme: &Theme) {
+    let popup = centered_rect(68, 23, area);
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::new().fg(theme.accent))
+        .title(" Keyboard shortcuts ");
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let text = vec![
+        Line::styled("Search input", Style::new().bold().fg(theme.accent)),
+        Line::raw("  Type                         Edit the search query"),
+        Line::raw("  ← / →, Ctrl+B / Ctrl+F      Move the cursor"),
+        Line::raw("  Home / End, Ctrl+A / Ctrl+E Move to the start / end"),
+        Line::raw("  Backspace / Delete, Ctrl+D  Delete a character"),
+        Line::raw("  Ctrl+W / Ctrl+U             Delete word / to start"),
+        Line::raw("  Tab / Shift+Tab             Complete / cycle agent"),
+        Line::raw(""),
+        Line::styled("Results", Style::new().bold().fg(theme.accent)),
+        Line::raw("  ↑ / ↓, Ctrl+K / Ctrl+J      Move selection"),
+        Line::raw("  Page Up / Page Down         Move by 10 results"),
+        Line::raw(""),
+        Line::styled("Preview and actions", Style::new().bold().fg(theme.accent)),
+        Line::raw("  Enter                        Resume session"),
+        Line::raw("  Ctrl+Y                      Copy resume command"),
+        Line::raw("  Ctrl+P                      Toggle preview"),
+        Line::raw("  Alt++ / Alt+-               Scroll preview"),
+        Line::raw("  Mouse wheel                 Scroll under pointer"),
+        Line::raw("  Esc / Ctrl+C                Quit"),
+        Line::raw(""),
+        Line::styled(
+            "F1 or Esc closes this help",
+            Style::new().fg(theme.muted).italic(),
+        ),
+    ];
+    frame.render_widget(Paragraph::new(text), inner);
 }
 
 fn draw_yolo_modal(frame: &mut Frame, area: Rect, modal: &YoloModal, theme: &Theme) {
@@ -1032,6 +1076,7 @@ mod tests {
 
         assert!(rendered.contains("copied: codex resume abc"));
         assert!(rendered.contains("Enter"));
+        assert!(rendered.contains("F1"));
     }
 
     #[test]

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -79,6 +79,7 @@ pub(super) struct AppState {
     pub(super) refresh_status: String,
     pub(super) last_search_ms: f64,
     pub(super) show_preview: bool,
+    pub(super) show_help: bool,
     pub(super) modal: Option<YoloModal>,
     pub(super) images: Option<AgentImages>,
     pub(super) theme: Theme,
@@ -137,6 +138,7 @@ impl AppState {
             refresh_status: "refreshing session stores".to_string(),
             last_search_ms: 0.0,
             show_preview: true,
+            show_help: false,
             modal: None,
             images,
             theme,
@@ -389,24 +391,40 @@ impl AppState {
     }
 
     pub(super) fn backspace(&mut self) {
-        if self.cursor == 0 {
-            return;
-        }
-        let start = char_to_byte_idx(&self.query, self.cursor - 1);
-        let end = char_to_byte_idx(&self.query, self.cursor);
-        self.query.replace_range(start..end, "");
-        self.cursor -= 1;
-        self.clear_explicit_filter_if_query_has_agent();
-        self.request_search();
+        self.delete_char_range(self.cursor.saturating_sub(1), self.cursor);
     }
 
     pub(super) fn delete(&mut self) {
-        if self.cursor >= self.query.chars().count() {
+        self.delete_char_range(self.cursor, self.cursor.saturating_add(1));
+    }
+
+    pub(super) fn delete_to_start(&mut self) {
+        self.delete_char_range(0, self.cursor);
+    }
+
+    pub(super) fn delete_previous_word(&mut self) {
+        let chars: Vec<_> = self.query.chars().collect();
+        let mut start = self.cursor.min(chars.len());
+        while start > 0 && chars[start - 1].is_whitespace() {
+            start -= 1;
+        }
+        while start > 0 && !chars[start - 1].is_whitespace() {
+            start -= 1;
+        }
+        self.delete_char_range(start, self.cursor);
+    }
+
+    fn delete_char_range(&mut self, start: usize, end: usize) {
+        let char_count = self.query.chars().count();
+        let start = start.min(char_count);
+        let end = end.min(char_count);
+        if start >= end {
             return;
         }
-        let start = char_to_byte_idx(&self.query, self.cursor);
-        let end = char_to_byte_idx(&self.query, self.cursor + 1);
-        self.query.replace_range(start..end, "");
+        let start_byte = char_to_byte_idx(&self.query, start);
+        let end_byte = char_to_byte_idx(&self.query, end);
+        self.query.replace_range(start_byte..end_byte, "");
+        self.cursor = start;
         self.clear_explicit_filter_if_query_has_agent();
         self.request_search();
     }


### PR DESCRIPTION
The Rust TUI no longer exposed a complete keyboard reference and only supported basic cursor keys. This adds an `F1` shortcut overlay, advertises it in the footer, and restores non-conflicting Emacs-style editing controls for search: `Ctrl+A/E/B/F/D/W/U`.

Existing result and action bindings such as `Ctrl+J/K`, `Ctrl+P`, and `Ctrl+Y` remain unchanged. Closes #88.


