### PR TITLE
feat(nix): add first-class flake package

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-26, macos-26-intel]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-26]
     steps:
       - uses: actions/checkout@v7
       - uses: cachix/install-nix-action@v31.11.1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -71,6 +71,19 @@ jobs:
       - name: Build
         run: cargo build --locked
 
+  nix:
+    name: Nix (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-26, macos-26-intel]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: cachix/install-nix-action@v31.11.1
+      - name: Build and test flake outputs
+        run: nix flake check --no-update-lock-file --print-build-logs
+
   npm-package:
     name: npm package
     runs-on: ubuntu-latest
@@ -149,7 +162,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [commitlint, rust, npm-package, python-wheel]
+    needs: [commitlint, rust, nix, npm-package, python-wheel]
     if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'workflow_dispatch'
     # Prevent concurrent releases from racing (would cause "tag already exists" errors)
     concurrency:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ brew tap angristan/tap
 brew install fast-resume
 ```
 
+Nix users can run directly from the source package:
+
+```bash
+nix run github:angristan/fast-resume
+```
+
 You can also install with npm or a binary wheel with `uv`:
 
 ```bash
@@ -40,7 +46,7 @@ npm install --global fast-resume
 uv tool install fast-resume
 ```
 
-See the [installation guide](docs/installation.md) for npm, `uvx`, Cargo, supported platforms, and terminal recommendations.
+See the [installation guide](docs/installation.md) for Nix, npm, `uvx`, Cargo, supported platforms, and terminal recommendations.
 
 ## Quick start
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -23,6 +23,7 @@ cargo fmt --all --check
 cargo clippy --all-targets --locked -- -D warnings
 cargo test --locked
 cargo build --release --locked
+nix flake check --no-update-lock-file
 git diff --check
 ```
 
@@ -52,7 +53,10 @@ fast-resume/
 ├── skills/                 # Portable Agent Skills embedded by the CLI
 ├── docs/                   # User and contributor documentation
 ├── Cargo.toml              # Rust dependencies and binary metadata
-└── pyproject.toml          # Maturin/PyPI metadata
+├── pyproject.toml          # Maturin/PyPI metadata
+├── flake.nix               # Nix package, app, checks, and development shell
+├── flake.lock              # Pinned standalone Nixpkgs revision
+└── nix/package.nix         # Source-based Rust package derivation
 ```
 
 ## Main components
@@ -67,6 +71,10 @@ fast-resume/
 | SQLite | [rusqlite](https://docs.rs/rusqlite/latest/rusqlite/) |
 
 ## Packaging
+
+The Nix flake builds directly from the repository source and committed
+`Cargo.lock`. Its package version comes from `Cargo.toml`, so release commits do
+not need a separate Nix version bump. CI checks the package on Linux and macOS.
 
 `maturin` builds PyPI wheels containing the Rust binary and compatibility commands. The same wheel builds supply npm's native variants. All variants use the `fast-resume` package name with platform prerelease versions such as `2.7.0-linux-x64`. The launcher selects one through an npm alias in `optionalDependencies`; it does not download code from an install script.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -50,8 +50,11 @@ environment.systemPackages = [
 ];
 ```
 
-The flake builds `fr` from the committed Rust source and `Cargo.lock`. The
-consumer's lock file pins both fast-resume and its tested Nixpkgs revision.
+The flake builds `fr` from the committed Rust source and `Cargo.lock`. It
+supports Linux ARM64/x86_64 and macOS Apple Silicon. Current Nixpkgs no longer
+supports Intel macOS; use Homebrew, npm, or PyPI there.
+
+The consumer's lock file pins both fast-resume and its tested Nixpkgs revision.
 Advanced configurations can make the input follow the host's Nixpkgs after
 verifying that its Rust toolchain satisfies fast-resume's minimum version.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,6 +22,39 @@ brew update
 brew upgrade fast-resume
 ```
 
+## Nix
+
+Run the source package without installing it:
+
+```bash
+nix run github:angristan/fast-resume
+```
+
+Install it into a user profile:
+
+```bash
+nix profile install github:angristan/fast-resume
+```
+
+For a declarative NixOS configuration, add fast-resume as a flake input:
+
+```nix
+inputs.fast-resume.url = "github:angristan/fast-resume";
+```
+
+Then include its package in the host module where `inputs` is available:
+
+```nix
+environment.systemPackages = [
+  inputs.fast-resume.packages.${pkgs.system}.default
+];
+```
+
+The flake builds `fr` from the committed Rust source and `Cargo.lock`. The
+consumer's lock file pins both fast-resume and its tested Nixpkgs revision.
+Advanced configurations can make the input follow the host's Nixpkgs after
+verifying that its Rust toolchain satisfies fast-resume's minimum version.
+
 ## npm
 
 Install globally with npm:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787964612,
+        "narHash": "sha256-0N9nghg3nwzX6b6qc77EzjR9cu/Z+UR66FlfsCqiURs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e8be7818e19ada32105a8af937a6a473b38167ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "Fast fuzzy finder for coding agent session history";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+      pkgsFor = system: import nixpkgs { inherit system; };
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+          fast-resume = pkgs.callPackage ./nix/package.nix { };
+        in
+        {
+          inherit fast-resume;
+          default = fast-resume;
+        }
+      );
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/fr";
+        };
+      });
+
+      checks = forAllSystems (system: {
+        package = self.packages.${system}.default;
+      });
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              cargo
+              clippy
+              rustc
+              rustfmt
+            ];
+          };
+        }
+      );
+
+      formatter = forAllSystems (system: (pkgsFor system).nixfmt);
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,6 @@
       systems = [
         "aarch64-darwin"
         "aarch64-linux"
-        "x86_64-darwin"
         "x86_64-linux"
       ];
       forAllSystems = nixpkgs.lib.genAttrs systems;

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -40,7 +40,6 @@ rustPlatform.buildRustPackage {
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"
-      "x86_64-darwin"
       "x86_64-linux"
     ];
   };

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  rustPlatform,
+  versionCheckHook,
+}:
+let
+  manifest = builtins.fromTOML (builtins.readFile ../Cargo.toml);
+in
+rustPlatform.buildRustPackage {
+  pname = manifest.package.name;
+  inherit (manifest.package) version;
+
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../Cargo.toml
+      ../Cargo.lock
+      ../src
+      ../tests
+      ../assets
+      ../skills
+    ];
+  };
+  cargoLock.lockFile = ../Cargo.lock;
+
+  postInstall = ''
+    ln -s fr "$out/bin/fast-resume"
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    description = manifest.package.description;
+    homepage = "https://github.com/angristan/fast-resume";
+    changelog = "https://github.com/angristan/fast-resume/blob/v${manifest.package.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "fr";
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}


### PR DESCRIPTION
Adds a source-based Nix package and flake so fast-resume can be built, run, and installed without Homebrew, npm, or PyPI. The flake exposes the package, app, development shell, formatter, and checks for the four release platforms.

CI now builds the Nix package on Linux and macOS, and releases depend on those checks. Installation and contributor documentation cover the new workflow.

<details>
<summary>Verification</summary>

- `cargo fmt --all --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked`
- `cargo build --release --locked`
- `git diff --check`
- Nix flake validation runs in this PR's CI because the current Arch host does not have Nix installed.

</details>